### PR TITLE
Rebuild state sequentially

### DIFF
--- a/src/main/java/com/yahoo/omid/tso/persistence/BookKeeperStateBuilder.java
+++ b/src/main/java/com/yahoo/omid/tso/persistence/BookKeeperStateBuilder.java
@@ -19,6 +19,7 @@ package com.yahoo.omid.tso.persistence;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +44,6 @@ import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.yahoo.omid.tso.TSOServerConfig;
 import com.yahoo.omid.tso.TSOState;
@@ -233,11 +233,12 @@ public class BookKeeperStateBuilder extends StateBuilder {
                 LOG.error("Error while reading ledger entries." + BKException.getMessage(rc));
                 context.setState(null);
             } else {
-                while(entries.hasMoreElements()){
-                    LedgerEntry le = entries.nextElement();
+                List<LedgerEntry> entryList = Collections.list(entries);
+                for (LedgerEntry le : Lists.reverse(entryList)) {
                     ByteBuffer entry = ByteBuffer.wrap(le.getEntry());
 
-                    context.readEntries.add(entry);
+                    // Add entries to readEntries for later execution
+                    context.readEntries.add(entry.duplicate());
                     lp.scan(entry);
 
                     if(lp.finishedScan() || le.getEntryId() == 0){

--- a/src/main/java/com/yahoo/omid/tso/persistence/LogExecutor.java
+++ b/src/main/java/com/yahoo/omid/tso/persistence/LogExecutor.java
@@ -1,0 +1,19 @@
+package com.yahoo.omid.tso.persistence;
+
+public interface LogExecutor {
+
+    void snapshot(int snapshot);
+
+    void logStart();
+
+    void fullAbort(long timestamp);
+
+    void abort(long timestamp);
+
+    void largestDeletedTimestamp(long timestamp);
+
+    void commit(long startTimestamp, long commitTimestamp);
+
+    void timestampOracle(long timestamp);
+
+}

--- a/src/main/java/com/yahoo/omid/tso/persistence/LogParser.java
+++ b/src/main/java/com/yahoo/omid/tso/persistence/LogParser.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LogParser {
-    private static final Logger LOG = LoggerFactory.getLogger(LoggerProtocol.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LogParser.class);
 
     LogParser() {
     }

--- a/src/main/java/com/yahoo/omid/tso/persistence/LogParser.java
+++ b/src/main/java/com/yahoo/omid/tso/persistence/LogParser.java
@@ -1,0 +1,63 @@
+package com.yahoo.omid.tso.persistence;
+
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.ABORT;
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.COMMIT;
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.FULLABORT;
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.LARGESTDELETEDTIMESTAMP;
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.LOGSTART;
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.SNAPSHOT;
+import static com.yahoo.omid.tso.persistence.LoggerProtocol.TIMESTAMPORACLE;
+
+import java.nio.ByteBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogParser {
+    private static final Logger LOG = LoggerFactory.getLogger(LoggerProtocol.class);
+
+    LogParser() {
+    }
+    
+    void parse(ByteBuffer bb, LogExecutor le){
+        boolean done = !bb.hasRemaining();
+        while(!done){
+            byte op = bb.get();
+            long timestamp, startTimestamp, commitTimestamp;
+            if(LOG.isTraceEnabled()){
+                LOG.trace("Operation: " + op);
+            }
+            switch(op){
+            case TIMESTAMPORACLE:
+                timestamp = bb.getLong();
+                le.timestampOracle(timestamp);
+                break;
+            case COMMIT:
+                startTimestamp = bb.getLong();
+                commitTimestamp = bb.getLong();
+                le.commit(startTimestamp, commitTimestamp);
+                break;
+            case LARGESTDELETEDTIMESTAMP:
+                timestamp = bb.getLong();
+                le.largestDeletedTimestamp(timestamp);
+                break;
+            case ABORT:
+                timestamp = bb.getLong();
+                le.abort(timestamp);
+                break;
+            case FULLABORT:
+                timestamp = bb.getLong();
+                le.fullAbort(timestamp);
+                break;
+            case LOGSTART:
+                le.logStart();
+                break;
+            case SNAPSHOT:
+                int snapshot = (int) bb.getLong();
+                le.snapshot(snapshot);
+                break;
+            }
+            if(bb.remaining() == 0) done = true;
+        }
+    }
+}


### PR DESCRIPTION
With this change we first scan the log until we reach a point where we can rebuild the whole state and afterwards we execute the log in order, from the oldest operation until the newest.