### PR TITLE
Disable cobertura in examples module

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,8 +10,8 @@
     </parent>
 
     <artifactId>examples</artifactId>
-    <name>Omid client examples</name>
-    <description>Omid client examples</description>
+    <name>Omid Client Examples</name>
+    <description>Includes some examples showing Omid features</description>
 
     <dependencies>
 
@@ -92,6 +92,15 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Disable cobertura execution for examples as they don't have tests -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
The reason is that examples don't have tests.

Also:

- Improve style

Change-Id: I50585dd0a1f65715a0e6bf5bfc9e20a6b6e463af