### PR TITLE
Disable cobertura in benchmarks module

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -67,6 +67,16 @@
                 </configuration>
             </plugin>
 
+            <!-- Disable cobertura execution for benchmarks as they don't have tests -->
+            <!-- TODO Enable cobertura when if we add tests to this module -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
         </plugins>
 
     </build>


### PR DESCRIPTION
Benchmarks does not contain tests for now. We want to measure the real test coverage of Omid so we have to filter this module for now.

Change-Id: I224666e9ab1a999aec39f2de77e5a0cc943eb481