### PR TITLE
Remove futures in CommitTable getters for Client and Writer interfaces

### DIFF
--- a/benchmarks/src/main/java/com/yahoo/omid/benchmarks/tso/TxRunner.java
+++ b/benchmarks/src/main/java/com/yahoo/omid/benchmarks/tso/TxRunner.java
@@ -92,8 +92,7 @@ public class TxRunner implements Runnable {
     private final Timer abortTimer;
     private final Counter errorCounter;
 
-    public TxRunner(MetricsRegistry metrics, Config expConfig) throws IOException, InterruptedException,
-            ExecutionException {
+    public TxRunner(MetricsRegistry metrics, Config expConfig) throws IOException {
 
         // Tx Runner config
         this.outstandingTxs = new Semaphore(expConfig.maxInFlight);
@@ -123,16 +122,8 @@ public class TxRunner implements Runnable {
             commitTable = new NullCommitTable();
             LOG.info("TxRunner-{} [ Using Null Commit Table ]", txRunnerId);
         }
-        try {
-            this.commitTableClient = commitTable.getClient().get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            e.printStackTrace();
-            throw e;
-        } catch (ExecutionException e) {
-            e.printStackTrace();
-            throw e;
-        }
+
+        this.commitTableClient = commitTable.getClient();
 
         // TSO Client initialization
         Configuration tsoConfig = new BaseConfiguration();
@@ -234,7 +225,7 @@ public class TxRunner implements Runnable {
             boolean readOnly = (randomGen.nextFloat() * 100) < percentReads;
 
             int txSize = readOnly ? 0 : randomGen.nextInt(maxTxSize);
-            final Set<CellId> cells = new HashSet<CellId>();
+            final Set<CellId> cells = new HashSet<>();
             for (byte i = 0; i < txSize; i++) {
                 long cellId = intGenerator.nextInt();
                 cells.add(new DummyCellIdImpl(cellId));

--- a/commit-table/src/main/java/com/yahoo/omid/committable/CommitTable.java
+++ b/commit-table/src/main/java/com/yahoo/omid/committable/CommitTable.java
@@ -25,9 +25,9 @@ public interface CommitTable {
 
     long INVALID_TRANSACTION_MARKER = -1L;
 
-    ListenableFuture<Writer> getWriter();
+    Writer getWriter() throws IOException;
 
-    ListenableFuture<Client> getClient();
+    Client getClient() throws IOException;
 
     interface Writer extends Closeable {
 
@@ -70,9 +70,9 @@ public interface CommitTable {
         ListenableFuture<Boolean> tryInvalidateTransaction(long startTimeStamp);
     }
 
-    // ************************************************************************
+    // ----------------------------------------------------------------------------------------------------------------
     // Helper classes
-    // ************************************************************************
+    // ----------------------------------------------------------------------------------------------------------------
     class CommitTimestamp {
 
         public enum Location {
@@ -103,10 +103,7 @@ public interface CommitTable {
 
         @Override
         public String toString() {
-            return String.format("Is valid=%s, Location=%s, Value=%d)",
-                    isValid,
-                    location,
-                    value);
+            return String.format("Is valid=%s, Location=%s, Value=%d)", isValid, location, value);
         }
 
     }

--- a/commit-table/src/main/java/com/yahoo/omid/committable/InMemoryCommitTable.java
+++ b/commit-table/src/main/java/com/yahoo/omid/committable/InMemoryCommitTable.java
@@ -25,22 +25,18 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class InMemoryCommitTable implements CommitTable {
 
-    final ConcurrentHashMap<Long, Long> table = new ConcurrentHashMap<Long, Long>();
+    final ConcurrentHashMap<Long, Long> table = new ConcurrentHashMap<>();
 
     long lowWatermark;
 
     @Override
-    public ListenableFuture<CommitTable.Writer> getWriter() {
-        SettableFuture<CommitTable.Writer> f = SettableFuture.<CommitTable.Writer>create();
-        f.set(new Writer());
-        return f;
+    public CommitTable.Writer getWriter() {
+        return new Writer();
     }
 
     @Override
-    public ListenableFuture<CommitTable.Client> getClient() {
-        SettableFuture<CommitTable.Client> f = SettableFuture.<CommitTable.Client>create();
-        f.set(new Client());
-        return f;
+    public CommitTable.Client getClient() {
+        return new Client();
     }
 
     public class Writer implements CommitTable.Writer {
@@ -75,16 +71,15 @@ public class InMemoryCommitTable implements CommitTable {
     public class Client implements CommitTable.Client {
         @Override
         public ListenableFuture<Optional<CommitTimestamp>> getCommitTimestamp(long startTimestamp) {
-            SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.<Optional<CommitTimestamp>>create();
+            SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.create();
             Long result = table.get(startTimestamp);
             if (result == null) {
                 f.set(Optional.<CommitTimestamp>absent());
             } else {
                 if (result == INVALID_TRANSACTION_MARKER) {
-                    f.set(Optional.<CommitTimestamp>of(new CommitTimestamp(Location.COMMIT_TABLE,
-                            INVALID_TRANSACTION_MARKER, false)));
+                    f.set(Optional.of(new CommitTimestamp(Location.COMMIT_TABLE, INVALID_TRANSACTION_MARKER, false)));
                 } else {
-                    f.set(Optional.<CommitTimestamp>of(new CommitTimestamp(Location.COMMIT_TABLE, result, true)));
+                    f.set(Optional.of(new CommitTimestamp(Location.COMMIT_TABLE, result, true)));
                 }
             }
             return f;
@@ -92,14 +87,14 @@ public class InMemoryCommitTable implements CommitTable {
 
         @Override
         public ListenableFuture<Long> readLowWatermark() {
-            SettableFuture<Long> f = SettableFuture.<Long>create();
+            SettableFuture<Long> f = SettableFuture.create();
             f.set(lowWatermark);
             return f;
         }
 
         @Override
         public ListenableFuture<Void> completeTransaction(long startTimestamp) {
-            SettableFuture<Void> f = SettableFuture.<Void>create();
+            SettableFuture<Void> f = SettableFuture.create();
             table.remove(startTimestamp);
             f.set(null);
             return f;
@@ -108,7 +103,7 @@ public class InMemoryCommitTable implements CommitTable {
         @Override
         public ListenableFuture<Boolean> tryInvalidateTransaction(long startTimestamp) {
 
-            SettableFuture<Boolean> f = SettableFuture.<Boolean>create();
+            SettableFuture<Boolean> f = SettableFuture.create();
             Long old = table.get(startTimestamp);
 
             // If the transaction represented by startTimestamp is not in the map

--- a/commit-table/src/main/java/com/yahoo/omid/committable/NullCommitTable.java
+++ b/commit-table/src/main/java/com/yahoo/omid/committable/NullCommitTable.java
@@ -23,17 +23,13 @@ import java.io.IOException;
 
 public class NullCommitTable implements CommitTable {
     @Override
-    public ListenableFuture<CommitTable.Writer> getWriter() {
-        SettableFuture<CommitTable.Writer> f = SettableFuture.<CommitTable.Writer>create();
-        f.set(new Writer());
-        return f;
+    public CommitTable.Writer getWriter() {
+        return new Writer();
     }
 
     @Override
-    public ListenableFuture<CommitTable.Client> getClient() {
-        SettableFuture<CommitTable.Client> f = SettableFuture.<CommitTable.Client>create();
-        f.set(new Client());
-        return f;
+    public CommitTable.Client getClient() {
+        return new Client();
     }
 
     public class Writer implements CommitTable.Writer {
@@ -76,7 +72,7 @@ public class NullCommitTable implements CommitTable {
 
         @Override
         public ListenableFuture<Void> completeTransaction(long startTimestamp) {
-            SettableFuture<Void> f = SettableFuture.<Void>create();
+            SettableFuture<Void> f = SettableFuture.create();
             f.set(null);
             return f;
         }

--- a/commit-table/src/test/java/com/yahoo/omid/committable/NullCommitTableTest.java
+++ b/commit-table/src/test/java/com/yahoo/omid/committable/NullCommitTableTest.java
@@ -13,13 +13,13 @@ public class NullCommitTableTest {
     private static final long TEST_CT = 2L;
     private static final long TEST_LWM = 1L;
 
-    @Test
+    @Test(timeOut = 10_000)
     public void testClientAndWriter() throws Exception {
 
         CommitTable commitTable = new NullCommitTable();
 
-        try (CommitTable.Client commitTableClient = commitTable.getClient().get();
-             CommitTable.Writer commitTableWriter = commitTable.getWriter().get()) {
+        try (CommitTable.Client commitTableClient = commitTable.getClient();
+             CommitTable.Writer commitTableWriter = commitTable.getWriter()) {
 
             // Test client
             try {

--- a/hbase-client/src/main/java/com/yahoo/omid/transaction/HBaseTransactionManager.java
+++ b/hbase-client/src/main/java/com/yahoo/omid/transaction/HBaseTransactionManager.java
@@ -98,14 +98,10 @@ public class HBaseTransactionManager extends AbstractTransactionManager implemen
                 try {
                     String commitTableName = conf.get(CommitTableConstants.COMMIT_TABLE_NAME_KEY, CommitTableConstants.COMMIT_TABLE_DEFAULT_NAME);
                     HBaseCommitTableConfig config = new HBaseCommitTableConfig(commitTableName);
-                    CommitTable commitTable =
-                            new HBaseCommitTable(conf, config);
-                    commitTableClient = commitTable.getClient().get();
+                    CommitTable commitTable = new HBaseCommitTable(conf, config);
+                    commitTableClient = commitTable.getClient();
                     ownsCommitTableClient = true;
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new OmidInstantiationException("Interrupted whilst creating the HBase transaction manager", e);
-                } catch (ExecutionException e) {
+                } catch (IOException e) {
                     throw new OmidInstantiationException("Exception whilst getting the CommitTable client", e);
                 }
             }
@@ -211,7 +207,6 @@ public class HBaseTransactionManager extends AbstractTransactionManager implemen
                     return false;
                 case CACHE: // cache was empty
                 default:
-                    assert (false);
                     return false;
             }
         } catch (IOException e) {

--- a/hbase-client/src/test/java/com/yahoo/omid/transaction/OmidTestBase.java
+++ b/hbase-client/src/test/java/com/yahoo/omid/transaction/OmidTestBase.java
@@ -155,7 +155,7 @@ public abstract class OmidTestBase {
     protected TransactionManager newTransactionManager(ITestContext context, TSOClient tsoClient) throws Exception {
         return HBaseTransactionManager.newBuilder()
                 .withConfiguration(hbaseConf)
-                .withCommitTableClient(getCommitTable(context).getClient().get())
+                .withCommitTableClient(getCommitTable(context).getClient())
                 .withTSOClient(tsoClient).build();
     }
 

--- a/hbase-client/src/test/java/com/yahoo/omid/transaction/TestFilters.java
+++ b/hbase-client/src/test/java/com/yahoo/omid/transaction/TestFilters.java
@@ -37,18 +37,18 @@ public class TestFilters extends OmidTestBase {
     private byte[] col1 = Bytes.toBytes("foobar");
     private byte[] col2 = Bytes.toBytes("boofar");
 
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testGetWithColumnPrefixFilter(ITestContext context) throws Exception {
         testGet(context, new ColumnPrefixFilter(prefix));
     }
 
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testGetWithValueFilter(ITestContext context) throws Exception {
         testGet(context, new ValueFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(col1)));
     }
 
     private void testGet(ITestContext context, Filter f) throws Exception {
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
 
         TSOClient client = TSOClient.newBuilder().withConfiguration(getClientConfiguration(context))
                 .build();
@@ -81,18 +81,18 @@ public class TestFilters extends OmidTestBase {
         assertEquals("shouldn't exist in result", 0, r.getColumnCells(family, col2).size());
     }
 
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testScanWithColumnPrefixFilter(ITestContext context) throws Exception {
         testScan(context, new ColumnPrefixFilter(prefix));
     }
 
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testScanWithValueFilter(ITestContext context) throws Exception {
         testScan(context, new ValueFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(col1)));
     }
 
     private void testScan(ITestContext context, Filter f) throws Exception {
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
         TSOClient client = TSOClient.newBuilder().withConfiguration(getClientConfiguration(context))
                 .build();
         TTable table = new TTable(hbaseConf, TEST_TABLE);

--- a/hbase-client/src/test/java/com/yahoo/omid/transaction/TestHBaseTransactionClient.java
+++ b/hbase-client/src/test/java/com/yahoo/omid/transaction/TestHBaseTransactionClient.java
@@ -35,7 +35,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     private static final byte[] qualifier = Bytes.toBytes("testdata");
     private static final byte[] data1 = Bytes.toBytes("testWrite-1");
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testIsCommitted(ITestContext context) throws Exception {
         TransactionManager tm = newTransactionManager(context);
         TTable table = new TTable(hbaseConf, TEST_TABLE);
@@ -70,7 +70,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
         assertTrue("row2 should be committed for kv3", hbaseTm.isCommitted(hBaseCellId3));
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testCrashAfterCommit(ITestContext context) throws Exception {
         AbstractTransactionManager tm = spy((AbstractTransactionManager) newTransactionManager(context));
         // The following line emulates a crash after commit that is observed in (*) below
@@ -110,7 +110,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
         assertTrue("row1 should be committed", hbaseTm.isCommitted(hBaseCellId));
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testReadCommitTimestampFromCommitTable(ITestContext context) throws Exception {
 
         final long NON_EXISTING_CELL_TS = 1000L;
@@ -161,7 +161,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
         }
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testReadCommitTimestampFromShadowCell(ITestContext context) throws Exception {
 
         final long NON_EXISTING_CELL_TS = 1L;
@@ -198,7 +198,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     }
 
     // Tests step 1 in AbstractTransactionManager.locateCellCommitTimestamp()
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCellCommitTimestampIsLocatedInCache(ITestContext context) throws Exception {
 
         final long CELL_ST = 1L;
@@ -209,7 +209,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
         // Pre-load the element to look for in the cache
         HTable table = new HTable(hbaseConf, TEST_TABLE);
         HBaseCellId hBaseCellId = new HBaseCellId(table, row1, family, qualifier, CELL_ST);
-        Map<Long, Long> fakeCache = Maps.<Long, Long>newHashMap();
+        Map<Long, Long> fakeCache = Maps.newHashMap();
         fakeCache.put(CELL_ST, CELL_CT);
 
         // Then test that locator finds it in the cache
@@ -224,7 +224,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     // Tests step 2 in AbstractTransactionManager.locateCellCommitTimestamp()
     // Note: This test is very similar to testCrashAfterCommit() above so
     // maybe we should merge them in this test, adding the missing assertions
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCellCommitTimestampIsLocatedInCommitTable(ITestContext context) throws Exception {
 
         AbstractTransactionManager tm = spy((AbstractTransactionManager) newTransactionManager(context));
@@ -260,7 +260,7 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     }
 
     // Tests step 3 in AbstractTransactionManager.locateCellCommitTimestamp()
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCellCommitTimestampIsLocatedInShadowCells(ITestContext context) throws Exception {
 
         HBaseTransactionManager tm = (HBaseTransactionManager) newTransactionManager(context);
@@ -289,16 +289,16 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     }
 
     // Tests step 4 in AbstractTransactionManager.locateCellCommitTimestamp()
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCellFromTransactionInPreviousEpochGetsInvalidComitTimestamp(ITestContext context) throws Exception {
 
         final long CURRENT_EPOCH_FAKE = 1000L;
 
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
         AbstractTransactionManager tm = spy((AbstractTransactionManager) newTransactionManager(context, commitTableClient));
         // The following lines allow to reach step 4)
         // in AbstractTransactionManager.locateCellCommitTimestamp()
-        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.<Optional<CommitTimestamp>>create();
+        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.create();
         f.set(Optional.<CommitTimestamp>absent());
         doReturn(f).when(commitTableClient).getCommitTimestamp(any(Long.class));
         doReturn(Optional.<CommitTimestamp>absent()).when(tm).readCommitTimestampFromShadowCell(any(Long.class),
@@ -328,16 +328,16 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     }
 
     // Tests step 5 in AbstractTransactionManager.locateCellCommitTimestamp()
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCellCommitTimestampIsLocatedInCommitTableAfterNotBeingInvalidated(ITestContext context) throws Exception {
 
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
         AbstractTransactionManager tm = spy((AbstractTransactionManager) newTransactionManager(context, commitTableClient));
         // The following line emulates a crash after commit that is observed in (*) below
         doThrow(new RuntimeException()).when(tm).updateShadowCells(any(HBaseTransaction.class));
         // The next two lines avoid steps 2) and 3) and go directly to step 5)
         // in AbstractTransactionManager.locateCellCommitTimestamp()
-        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.<Optional<CommitTimestamp>>create();
+        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.create();
         f.set(Optional.<CommitTimestamp>absent());
         doReturn(f).doCallRealMethod().when(commitTableClient).getCommitTimestamp(any(Long.class));
         doReturn(Optional.<CommitTimestamp>absent()).when(tm).readCommitTimestampFromShadowCell(any(Long.class),
@@ -372,14 +372,14 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     }
 
     // Tests step 6 in AbstractTransactionManager.locateCellCommitTimestamp()
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCellCommitTimestampIsLocatedInShadowCellsAfterNotBeingInvalidated(ITestContext context) throws Exception {
 
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
         AbstractTransactionManager tm = spy((AbstractTransactionManager) newTransactionManager(context, commitTableClient));
         // The next two lines avoid steps 2), 3) and 5) and go directly to step 6)
         // in AbstractTransactionManager.locateCellCommitTimestamp()
-        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.<Optional<CommitTimestamp>>create();
+        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.create();
         f.set(Optional.<CommitTimestamp>absent());
         doReturn(f).when(commitTableClient).getCommitTimestamp(any(Long.class));
         doReturn(Optional.<CommitTimestamp>absent()).doCallRealMethod()
@@ -410,15 +410,15 @@ public class TestHBaseTransactionClient extends OmidTestBase {
     }
 
     // Tests last step in AbstractTransactionManager.locateCellCommitTimestamp()
-    @Test(timeOut = 30000)
+    @Test(timeOut = 30_000)
     public void testCTLocatorReturnsAValidCTWhenNotPresent(ITestContext context) throws Exception {
 
         final long CELL_TS = 1L;
 
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
         AbstractTransactionManager tm = spy((AbstractTransactionManager) newTransactionManager(context, commitTableClient));
         // The following lines allow to reach the last return statement
-        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.<Optional<CommitTimestamp>>create();
+        SettableFuture<Optional<CommitTimestamp>> f = SettableFuture.create();
         f.set(Optional.<CommitTimestamp>absent());
         doReturn(f).when(commitTableClient).getCommitTimestamp(any(Long.class));
         doReturn(Optional.<CommitTimestamp>absent()).when(tm).readCommitTimestampFromShadowCell(any(Long.class),

--- a/hbase-client/src/test/java/com/yahoo/omid/transaction/TestShadowCells.java
+++ b/hbase-client/src/test/java/com/yahoo/omid/transaction/TestShadowCells.java
@@ -94,7 +94,7 @@ public class TestShadowCells extends OmidTestBase {
                 "Shadow cell should be there");
 
         // Test that we can make a valid read after adding a shadow cell without hitting the commit table
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
 
         TSOClient client = TSOClient.newBuilder().withConfiguration(getTSOClientDefaultConfiguration()).build();
         TransactionManager tm2 = HBaseTransactionManager.newBuilder()
@@ -112,7 +112,7 @@ public class TestShadowCells extends OmidTestBase {
 
     @Test(timeOut = 60_000)
     public void testCrashingAfterCommitDoesNotWriteShadowCells(ITestContext context) throws Exception {
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
 
         TSOClient client = TSOClient.newBuilder().withConfiguration(getTSOClientDefaultConfiguration()).build();
         AbstractTransactionManager tm = spy((AbstractTransactionManager) HBaseTransactionManager.newBuilder()
@@ -153,7 +153,7 @@ public class TestShadowCells extends OmidTestBase {
 
     @Test(timeOut = 60_000)
     public void testShadowCellIsHealedAfterCommitCrash(ITestContext context) throws Exception {
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
 
         TSOClient client = TSOClient.newBuilder().withConfiguration(getTSOClientDefaultConfiguration()).build();
         AbstractTransactionManager tm = spy((AbstractTransactionManager) HBaseTransactionManager.newBuilder()
@@ -208,7 +208,7 @@ public class TestShadowCells extends OmidTestBase {
     public void testTransactionNeverCompletesWhenCommitThrowsAnInternalTransactionManagerExceptionUpdatingShadowCells(
             ITestContext context)
             throws Exception {
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
 
         TSOClient client = TSOClient.newBuilder().withConfiguration(getTSOClientDefaultConfiguration()).build();
         AbstractTransactionManager tm = spy((AbstractTransactionManager) HBaseTransactionManager.newBuilder()
@@ -392,7 +392,7 @@ public class TestShadowCells extends OmidTestBase {
 
         // ensure that transaction is no longer in commit table
         // the only place that should have the mapping is the shadow cells
-        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient().get());
+        CommitTable.Client commitTableClient = spy(getCommitTable(context).getClient());
         Optional<CommitTable.CommitTimestamp> ct1 = commitTableClient.getCommitTimestamp(t1.getStartTimestamp()).get();
         Optional<CommitTable.CommitTimestamp> ct2 = commitTableClient.getCommitTimestamp(t2.getStartTimestamp()).get();
         Optional<CommitTable.CommitTimestamp> ct3 = commitTableClient.getCommitTimestamp(t3.getStartTimestamp()).get();

--- a/hbase-commit-table/src/main/java/com/yahoo/omid/committable/hbase/HBaseCommitTableTester.java
+++ b/hbase-commit-table/src/main/java/com/yahoo/omid/committable/hbase/HBaseCommitTableTester.java
@@ -82,14 +82,13 @@ public class HBaseCommitTableTester {
             keygen = new SeqKeyGenerator();
         } else {
             keygen = null;
-            assert (false);
         }
 
         HBaseLogin.loginIfNeeded(config.loginFlags);
 
         CommitTable commitTable = new HBaseCommitTable(hbaseConfig, COMMIT_TABLE_DEFAULT_NAME, keygen);
 
-        CommitTable.Writer writer = commitTable.getWriter().get();
+        CommitTable.Writer writer = commitTable.getWriter();
 
         MetricRegistry metrics = new MetricRegistry();
         if (config.graphite != null) {

--- a/hbase-commit-table/src/test/java/com/yahoo/omid/committable/hbase/TestHBaseCommitTable.java
+++ b/hbase-commit-table/src/test/java/com/yahoo/omid/committable/hbase/TestHBaseCommitTable.java
@@ -110,16 +110,14 @@ public class TestHBaseCommitTable {
         }
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testBasicBehaviour() throws Throwable {
         HBaseCommitTableConfig config = new HBaseCommitTableConfig();
         config.setTableName(TEST_TABLE);
         HBaseCommitTable commitTable = new HBaseCommitTable(hbaseConf, config);
 
-        ListenableFuture<Writer> futureWriter = commitTable.getWriter();
-        Writer writer = futureWriter.get();
-        ListenableFuture<Client> futureClient = commitTable.getClient();
-        Client client = futureClient.get();
+        Writer writer = commitTable.getWriter();
+        Client client = commitTable.getClient();
 
         // Test that the first time the table is empty
         assertEquals("Rows should be 0!", 0, rowCount(TABLE_NAME, COMMIT_TABLE_FAMILY));
@@ -142,7 +140,7 @@ public class TestHBaseCommitTable {
         assertEquals("Rows should be 1000!", 1000, rowCount(TABLE_NAME, COMMIT_TABLE_FAMILY));
 
         // Test the successful deletion of the 1000 txs
-        Future<Void> f = null;
+        Future<Void> f;
         for (long i = 0; i < 1000; i++) {
             f = client.completeTransaction(i);
             f.get();
@@ -175,7 +173,7 @@ public class TestHBaseCommitTable {
 
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testTransactionInvalidation() throws Throwable {
 
         // Prepare test
@@ -189,8 +187,8 @@ public class TestHBaseCommitTable {
         HBaseCommitTable commitTable = new HBaseCommitTable(hbaseConf, config);
 
         // Components under test
-        Writer writer = commitTable.getWriter().get();
-        Client client = commitTable.getClient().get();
+        Writer writer = commitTable.getWriter();
+        Client client = commitTable.getClient();
 
         // Test that initially the table is empty
         assertEquals("Rows should be 0!", 0, rowCount(TABLE_NAME, COMMIT_TABLE_FAMILY));
@@ -241,16 +239,14 @@ public class TestHBaseCommitTable {
 
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testClosingClientEmptyQueuesProperly() throws Throwable {
         HBaseCommitTableConfig config = new HBaseCommitTableConfig();
         config.setTableName(TEST_TABLE);
         HBaseCommitTable commitTable = new HBaseCommitTable(hbaseConf, config);
 
-        ListenableFuture<Writer> futureWriter = commitTable.getWriter();
-        Writer writer = futureWriter.get();
-        ListenableFuture<Client> futureClient = commitTable.getClient();
-        HBaseCommitTable.HBaseClient client = (HBaseClient) futureClient.get();
+        Writer writer = commitTable.getWriter();
+        HBaseCommitTable.HBaseClient client = (HBaseClient) commitTable.getClient();
 
         for (int i = 0; i < 1000; i++) {
             writer.addCommittedTransaction(i, i + 1);

--- a/hbase-coprocessor/src/main/java/com/yahoo/omid/transaction/OmidCompactor.java
+++ b/hbase-coprocessor/src/main/java/com/yahoo/omid/transaction/OmidCompactor.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
 
 import static com.yahoo.omid.committable.hbase.CommitTableConstants.COMMIT_TABLE_NAME_KEY;
 
@@ -131,16 +130,9 @@ public class OmidCompactor extends BaseRegionObserver {
     private CommitTable.Client initAndGetCommitTableClient() throws IOException {
         LOG.info("Trying to get the commit table client");
         CommitTable commitTable = new HBaseCommitTable(conf, commitTableConf);
-        try {
-            CommitTable.Client commitTableClient = commitTable.getClient().get();
-            LOG.info("Commit table client obtained {}", commitTableClient.getClass().getCanonicalName());
-            return commitTableClient;
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Interrupted getting the commit table client");
-        } catch (ExecutionException ee) {
-            throw new IOException("Error getting the commit table client", ee.getCause());
-        }
+        CommitTable.Client commitTableClient = commitTable.getClient();
+        LOG.info("Commit table client obtained {}", commitTableClient.getClass().getCanonicalName());
+        return commitTableClient;
     }
 
 }

--- a/hbase-coprocessor/src/test/java/com/yahoo/omid/transaction/TestCompaction.java
+++ b/hbase-coprocessor/src/test/java/com/yahoo/omid/transaction/TestCompaction.java
@@ -179,7 +179,7 @@ public class TestCompaction {
     private TransactionManager newTransactionManager() throws Exception {
         return HBaseTransactionManager.newBuilder()
                 .withConfiguration(hbaseConf)
-                .withCommitTableClient(commitTable.getClient().get())
+                .withCommitTableClient(commitTable.getClient())
                 .withTSOClient(client)
                 .build();
     }
@@ -214,7 +214,7 @@ public class TestCompaction {
         OmidCompactor omidCompactor = (OmidCompactor) hbaseCluster.getRegions(Bytes.toBytes(TEST_TABLE)).get(0)
                 .getCoprocessorHost().findCoprocessor(OmidCompactor.class.getName());
         CommitTable commitTable = injector.getInstance(CommitTable.class);
-        CommitTable.Client commitTableClient = spy(commitTable.getClient().get());
+        CommitTable.Client commitTableClient = spy(commitTable.getClient());
         SettableFuture<Long> f = SettableFuture.create();
         f.set(fakeAssignedLowWatermark);
         doReturn(f).when(commitTableClient).readLowWatermark();
@@ -271,7 +271,7 @@ public class TestCompaction {
         OmidCompactor omidCompactor = (OmidCompactor) hbaseCluster.getRegions(Bytes.toBytes(TEST_TABLE)).get(0)
                 .getCoprocessorHost().findCoprocessor(OmidCompactor.class.getName());
         CommitTable commitTable = injector.getInstance(CommitTable.class);
-        CommitTable.Client commitTableClient = spy(commitTable.getClient().get());
+        CommitTable.Client commitTableClient = spy(commitTable.getClient());
         SettableFuture<Long> f = SettableFuture.create();
         f.set(Long.MAX_VALUE);
         doReturn(f).when(commitTableClient).readLowWatermark();
@@ -358,7 +358,7 @@ public class TestCompaction {
         OmidCompactor omidCompactor = (OmidCompactor) hbaseCluster.getRegions(Bytes.toBytes(TEST_TABLE)).get(0)
                 .getCoprocessorHost().findCoprocessor(OmidCompactor.class.getName());
         CommitTable commitTable = injector.getInstance(CommitTable.class);
-        CommitTable.Client commitTableClient = spy(commitTable.getClient().get());
+        CommitTable.Client commitTableClient = spy(commitTable.getClient());
         SettableFuture<Long> f = SettableFuture.create();
         f.set(neverendingTxBelowLowWatermark.getStartTimestamp());
         doReturn(f).when(commitTableClient).readLowWatermark();
@@ -437,7 +437,7 @@ public class TestCompaction {
         OmidCompactor omidCompactor = (OmidCompactor) hbaseCluster.getRegions(Bytes.toBytes(TEST_TABLE)).get(0)
                 .getCoprocessorHost().findCoprocessor(OmidCompactor.class.getName());
         CommitTable commitTable = injector.getInstance(CommitTable.class);
-        CommitTable.Client commitTableClient = spy(commitTable.getClient().get());
+        CommitTable.Client commitTableClient = spy(commitTable.getClient());
         SettableFuture<Long> f = SettableFuture.create();
         f.setException(new IOException("Unable to read"));
         doReturn(f).when(commitTableClient).readLowWatermark();
@@ -780,14 +780,14 @@ public class TestCompaction {
                 0, result.getColumnCells(fam, qual).size());
     }
 
-    // ************************************************************************
+    // ----------------------------------------------------------------------------------------------------------------
     // Tests on tombstones and non-transactional Deletes
-    // ************************************************************************
+    // ----------------------------------------------------------------------------------------------------------------
 
     /**
      * Test that when a major compaction runs, cells that were deleted non-transactionally dissapear
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testACellDeletedNonTransactionallyDoesNotAppearWhenAMajorCompactionOccurs() throws Throwable {
         String TEST_TABLE = "testACellDeletedNonTransactionallyDoesNotAppearWhenAMajorCompactionOccurs";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -828,7 +828,7 @@ public class TestCompaction {
      * Test that when a minor compaction runs, cells that were deleted non-transactionally are preserved. This is to
      * allow users still access the cells when doing "improper" operations on a transactional table
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testACellDeletedNonTransactionallyIsPreservedWhenMinorCompactionOccurs() throws Throwable {
         String TEST_TABLE = "testACellDeletedNonTransactionallyIsPreservedWhenMinorCompactionOccurs";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -906,7 +906,7 @@ public class TestCompaction {
     /**
      * Test that when a minor compaction runs, tombstones are not cleaned up
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreNotCleanedUpWhenMinorCompactionOccurs() throws Throwable {
         String TEST_TABLE = "testTombstonesAreNotCleanedUpWhenMinorCompactionOccurs";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -987,7 +987,7 @@ public class TestCompaction {
     /**
      * Test that when compaction runs, tombstones are cleaned up case1: 1 put (ts < lwm) then tombstone (ts > lwm)
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreCleanedUpCase1() throws Exception {
         String TEST_TABLE = "testTombstonesAreCleanedUpCase1";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -1027,7 +1027,7 @@ public class TestCompaction {
     /**
      * Test that when compaction runs, tombstones are cleaned up case2: 1 put (ts < lwm) then tombstone (ts < lwm)
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreCleanedUpCase2() throws Exception {
         String TEST_TABLE = "testTombstonesAreCleanedUpCase2";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -1068,7 +1068,7 @@ public class TestCompaction {
      * Test that when compaction runs, tombstones are cleaned up case3: 1 put (ts < lwm) then tombstone (ts < lwm) not
      * committed
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreCleanedUpCase3() throws Exception {
         String TEST_TABLE = "testTombstonesAreCleanedUpCase3";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -1108,7 +1108,7 @@ public class TestCompaction {
      * Test that when compaction runs, tombstones are cleaned up case4: 1 put (ts < lwm) then tombstone (ts > lwm) not
      * committed
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreCleanedUpCase4() throws Exception {
         String TEST_TABLE = "testTombstonesAreCleanedUpCase4";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -1147,7 +1147,7 @@ public class TestCompaction {
     /**
      * Test that when compaction runs, tombstones are cleaned up case5: tombstone (ts < lwm)
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreCleanedUpCase5() throws Exception {
         String TEST_TABLE = "testTombstonesAreCleanedUpCase5";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -1175,7 +1175,7 @@ public class TestCompaction {
     /**
      * Test that when compaction runs, tombstones are cleaned up case6: tombstone (ts < lwm), then put (ts < lwm)
      */
-    @Test(timeOut = 60000)
+    @Test(timeOut = 60_000)
     public void testTombstonesAreCleanedUpCase6() throws Exception {
         String TEST_TABLE = "testTombstonesAreCleanedUpCase6";
         createTableIfNotExists(TEST_TABLE, Bytes.toBytes(TEST_FAMILY));
@@ -1216,7 +1216,7 @@ public class TestCompaction {
         OmidCompactor omidCompactor = (OmidCompactor) hbaseCluster.getRegions(Bytes.toBytes(tableName)).get(0)
                 .getCoprocessorHost().findCoprocessor(OmidCompactor.class.getName());
         CommitTable commitTable = injector.getInstance(CommitTable.class);
-        CommitTable.Client commitTableClient = spy(commitTable.getClient().get());
+        CommitTable.Client commitTableClient = spy(commitTable.getClient());
         SettableFuture<Long> f = SettableFuture.create();
         f.set(lwm);
         doReturn(f).when(commitTableClient).readLowWatermark();

--- a/transaction-client/src/test/java/com/yahoo/omid/tsoclient/TestMockTSOClient.java
+++ b/transaction-client/src/test/java/com/yahoo/omid/tsoclient/TestMockTSOClient.java
@@ -20,15 +20,15 @@ public class TestMockTSOClient {
     @Test(timeOut = 10000)
     public void testConflicts() throws Exception {
         CommitTable commitTable = new InMemoryCommitTable();
-        TSOProtocol client = new MockTSOClient(commitTable.getWriter().get());
+        TSOProtocol client = new MockTSOClient(commitTable.getWriter());
 
         long tr1 = client.getNewStartTimestamp().get();
         long tr2 = client.getNewStartTimestamp().get();
 
-        long cr1 = client.commit(tr1, Sets.newHashSet(c1)).get();
+        client.commit(tr1, Sets.newHashSet(c1)).get();
 
         try {
-            long cr2 = client.commit(tr2, Sets.newHashSet(c1, c2)).get();
+            client.commit(tr2, Sets.newHashSet(c1, c2)).get();
             Assert.fail("Shouldn't have committed");
         } catch (ExecutionException ee) {
             assertEquals("Should have aborted", ee.getCause().getClass(), AbortException.class);
@@ -38,8 +38,8 @@ public class TestMockTSOClient {
     @Test(timeOut = 10000)
     public void testWatermarkUpdate() throws Exception {
         CommitTable commitTable = new InMemoryCommitTable();
-        TSOProtocol client = new MockTSOClient(commitTable.getWriter().get());
-        CommitTable.Client commitTableClient = commitTable.getClient().get();
+        TSOProtocol client = new MockTSOClient(commitTable.getWriter());
+        CommitTable.Client commitTableClient = commitTable.getClient();
 
         long tr1 = client.getNewStartTimestamp().get();
         client.commit(tr1, Sets.newHashSet(c1)).get();

--- a/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessorImpl.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessorImpl.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +80,7 @@ class PersistenceProcessorImpl
                              RetryProcessor retryProc,
                              Panicker panicker,
                              TSOServerCommandLineConfig config)
-            throws InterruptedException, ExecutionException {
+            throws IOException {
         this(metrics,
                 tsoHostAndPort,
                 new Batch(config.getMaxBatchSize()),
@@ -103,13 +102,13 @@ class PersistenceProcessorImpl
                              RetryProcessor retryProc,
                              Panicker panicker,
                              TSOServerCommandLineConfig config)
-            throws InterruptedException, ExecutionException {
+            throws IOException {
 
         this.tsoHostAndPort = tsoHostAndPort;
         this.batch = batch;
         this.leaseManager = leaseManager;
-        this.commitTableClient = commitTable.getClient().get();
-        this.writer = commitTable.getWriter().get();
+        this.commitTableClient = commitTable.getClient();
+        this.writer = commitTable.getWriter();
         this.reply = reply;
         this.retryProc = retryProc;
         this.panicker = panicker;
@@ -129,7 +128,7 @@ class PersistenceProcessorImpl
         persistRing = RingBuffer.createSingleProducer(
                 PersistEvent.EVENT_FACTORY, 1 << 20, timeoutStrategy); // 2^20 entries in ringbuffer
         SequenceBarrier persistSequenceBarrier = persistRing.newBarrier();
-        BatchEventProcessor<PersistEvent> persistProcessor = new BatchEventProcessor<PersistEvent>(
+        BatchEventProcessor<PersistEvent> persistProcessor = new BatchEventProcessor<>(
                 persistRing,
                 persistSequenceBarrier,
                 this);

--- a/tso-server/src/main/java/com/yahoo/omid/tso/RetryProcessorImpl.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/RetryProcessorImpl.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,8 +44,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  * Manages the retry requests that clients can send when they did
  * not received the response in the specified timeout
  */
-class RetryProcessorImpl
-        implements EventHandler<RetryProcessorImpl.RetryEvent>, RetryProcessor {
+class RetryProcessorImpl implements EventHandler<RetryProcessorImpl.RetryEvent>, RetryProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(RetryProcessor.class);
 
@@ -59,22 +59,19 @@ class RetryProcessorImpl
     final Meter retriesMeter;
 
     @Inject
-    RetryProcessorImpl(MetricsRegistry metrics, CommitTable commitTable,
-                       ReplyProcessor replyProc, Panicker panicker)
-            throws InterruptedException, ExecutionException {
-        this.commitTableClient = commitTable.getClient().get();
-        this.writer = commitTable.getWriter().get();
+    RetryProcessorImpl(MetricsRegistry metrics, CommitTable commitTable, ReplyProcessor replyProc, Panicker panicker)
+            throws IOException
+    {
+
+        this.commitTableClient = commitTable.getClient();
+        this.writer = commitTable.getWriter();
         this.replyProc = replyProc;
 
         WaitStrategy strategy = new YieldingWaitStrategy();
 
-        retryRing = RingBuffer.<RetryEvent>createSingleProducer(
-                RetryEvent.EVENT_FACTORY, 1 << 12, strategy);
-        SequenceBarrier retrySequenceBarrier = retryRing.newBarrier();
-        BatchEventProcessor<RetryEvent> retryProcessor = new BatchEventProcessor<RetryEvent>(
-                retryRing,
-                retrySequenceBarrier,
-                this);
+        retryRing = RingBuffer.createSingleProducer(RetryEvent.EVENT_FACTORY, 1 << 12, strategy);
+        SequenceBarrier retrySeqBarrier = retryRing.newBarrier();
+        BatchEventProcessor<RetryEvent> retryProcessor = new BatchEventProcessor<>(retryRing, retrySeqBarrier, this);
         retryProcessor.setExceptionHandler(new FatalExceptionHandler(panicker));
 
         retryRing.addGatingSequences(retryProcessor.getSequence());

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestPanicker.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestPanicker.java
@@ -1,7 +1,5 @@
 package com.yahoo.omid.tso;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.yahoo.omid.committable.CommitTable;
 import com.yahoo.omid.metrics.MetricsRegistry;
 import com.yahoo.omid.timestamp.storage.TimestampStorage;
@@ -86,17 +84,13 @@ public class TestPanicker {
         final CommitTable.Client mockClient = mock(CommitTable.Client.class);
         CommitTable commitTable = new CommitTable() {
             @Override
-            public ListenableFuture<Writer> getWriter() {
-                SettableFuture<Writer> f = SettableFuture.create();
-                f.set(mockWriter);
-                return f;
+            public Writer getWriter() {
+                return mockWriter;
             }
 
             @Override
-            public ListenableFuture<Client> getClient() {
-                SettableFuture<Client> f = SettableFuture.create();
-                f.set(mockClient);
-                return f;
+            public Client getClient() {
+                return mockClient;
             }
         };
 
@@ -127,17 +121,13 @@ public class TestPanicker {
         final CommitTable.Client mockClient = mock(CommitTable.Client.class);
         CommitTable commitTable = new CommitTable() {
             @Override
-            public ListenableFuture<Writer> getWriter() {
-                SettableFuture<Writer> f = SettableFuture.create();
-                f.set(mockWriter);
-                return f;
+            public Writer getWriter() {
+                return mockWriter;
             }
 
             @Override
-            public ListenableFuture<Client> getClient() {
-                SettableFuture<Client> f = SettableFuture.create();
-                f.set(mockClient);
-                return f;
+            public Client getClient() {
+                return mockClient;
             }
         };
         PersistenceProcessor proc = new PersistenceProcessorImpl(metrics,

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestPersistenceProcessor.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestPersistenceProcessor.java
@@ -1,7 +1,5 @@
 package com.yahoo.omid.tso;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.yahoo.omid.committable.CommitTable;
 import com.yahoo.omid.metrics.MetricsRegistry;
 import com.yahoo.omid.metrics.NullMetricsProvider;
@@ -63,17 +61,13 @@ public class TestPersistenceProcessor {
         // Configure commit table to return the mocked writer and client
         commitTable = new CommitTable() {
             @Override
-            public ListenableFuture<Writer> getWriter() {
-                SettableFuture<Writer> f = SettableFuture.<Writer>create();
-                f.set(mockWriter);
-                return f;
+            public Writer getWriter() {
+                return mockWriter;
             }
 
             @Override
-            public ListenableFuture<Client> getClient() {
-                SettableFuture<Client> f = SettableFuture.<Client>create();
-                f.set(mockClient);
-                return f;
+            public Client getClient() {
+                return mockClient;
             }
         };
     }

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestRetryProcessor.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestRetryProcessor.java
@@ -66,7 +66,7 @@ public class TestRetryProcessor {
         assertEquals("Captured timestamp should be the same as NON_EXISTING_ST_TX", NON_EXISTING_ST_TX, startTS);
 
         // Test we'll reply with a commit for a retry request when the start timestamp IS in the commit table
-        commitTable.getWriter().get().addCommittedTransaction(ST_TX_1, CT_TX_1); // Add a tx to commit table
+        commitTable.getWriter().addCommittedTransaction(ST_TX_1, CT_TX_1); // Add a tx to commit table
 
         retryProc.disambiguateRetryRequestHeuristically(ST_TX_1, channel, new MonitoringContext(metrics));
         ArgumentCaptor<Long> secondTScapture = ArgumentCaptor.forClass(Long.class);
@@ -83,11 +83,11 @@ public class TestRetryProcessor {
     public void testRetriedRequestForInvalidatedTransactionReturnsAnAbort() throws Exception {
 
         // Invalidate the transaction
-        commitTable.getClient().get().tryInvalidateTransaction(ST_TX_1);
+        commitTable.getClient().tryInvalidateTransaction(ST_TX_1);
 
         // Pre-start verification: Validate that the transaction is invalidated
         // NOTE: This test should be in the a test class for InMemoryCommitTable
-        Optional<CommitTimestamp> invalidTxMarker = commitTable.getClient().get().getCommitTimestamp(ST_TX_1).get();
+        Optional<CommitTimestamp> invalidTxMarker = commitTable.getClient().getCommitTimestamp(ST_TX_1).get();
         Assert.assertTrue(invalidTxMarker.isPresent());
         Assert.assertEquals(invalidTxMarker.get().getValue(), InMemoryCommitTable.INVALID_TRANSACTION_MARKER);
 

--- a/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestIntegrationOfTSOClientServerBasicFunctionality.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestIntegrationOfTSOClientServerBasicFunctionality.java
@@ -59,7 +59,7 @@ public class TestIntegrationOfTSOClientServerBasicFunctionality {
         Injector injector = Guice.createInjector(tsoServerMockModule);
 
         CommitTable commitTable = injector.getInstance(CommitTable.class);
-        commitTableClient = commitTable.getClient().get();
+        commitTableClient = commitTable.getClient();
 
         LOG.info("==================================================================================================");
         LOG.info("======================================= Init TSO Server ==========================================");

--- a/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestTSOClientRequestAndResponseBehaviours.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestTSOClientRequestAndResponseBehaviours.java
@@ -360,7 +360,7 @@ public class TestTSOClientRequestAndResponseBehaviours {
 
         long tx1ST = client.getNewStartTimestamp().get();
         // Invalidate the transaction
-        commitTable.getClient().get().tryInvalidateTransaction(tx1ST);
+        commitTable.getClient().tryInvalidateTransaction(tx1ST);
 
         clientOneShot.makeRequest(createRetryCommitRequest(tx1ST));
         TSOProto.Response response = clientOneShot.makeRequest(createRetryCommitRequest(tx1ST));
@@ -380,7 +380,7 @@ public class TestTSOClientRequestAndResponseBehaviours {
         clientOneShot.makeRequest(createRetryCommitRequest(tx1ST));
 
         // Simulate remove entry from the commit table before exercise retry
-        commitTable.getClient().get().completeTransaction(tx1ST);
+        commitTable.getClient().completeTransaction(tx1ST);
 
         TSOProto.Response response = clientOneShot.makeRequest(createRetryCommitRequest(tx1ST));
         assertTrue(response.getCommitResponse().getAborted(), "Transaction should abort");


### PR DESCRIPTION
NOTE: No functional changes are introduced in this commit.

The futures returned in the getters introduced unnecessary verbosity that is not
required

Also:
- Remove redundant code related to generics
- Add timeouts to some tests missing them