### PR TITLE
Concurrent writes to the commit table

### DIFF
--- a/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessor.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessor.java
@@ -23,7 +23,6 @@ interface PersistenceProcessor {
     void persistAbort(long startTimestamp, boolean isRetry, Channel c, MonitoringContext monCtx);
 
     void persistTimestamp(long startTimestamp, Channel c, MonitoringContext monCtx);
-
     void persistLowWatermark(long lowWatermark, MonitoringContext monCtx);
     void persistFlush(boolean forTesting);
     void reset();

--- a/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessor.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessor.java
@@ -24,5 +24,7 @@ interface PersistenceProcessor {
 
     void persistTimestamp(long startTimestamp, Channel c, MonitoringContext monCtx);
 
-    void persistLowWatermark(long lowWatermark);
+    void persistLowWatermark(long lowWatermark, MonitoringContext monCtx);
+    void persistFlush(boolean forTesting);
+    void reset();
 }

--- a/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessorImpl.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessorImpl.java
@@ -57,7 +57,7 @@ class PersistenceProcessorImpl
     static final int DEFAULT_BATCH_PERSIST_TIMEOUT_MS = 100;
     static final String TSO_BATCH_PERSIST_TIMEOUT_MS_KEY = "tso.batch-persist-timeout-ms";
     static final String TSO_PERSIST_HANDLER_NUM = "tso.persist.handler";
-    static final int NUM_BUFFERS_PER_HANDLER = 25;
+    static final int NUM_BUFFERS_PER_HANDLER = 10;
 
     final ReplyProcessor reply;
     final RetryProcessor retryProc;
@@ -230,7 +230,6 @@ class PersistenceProcessorImpl
             public PersistBatchEvent newInstance() {
                 return new PersistBatchEvent();
             }
-
         };
     }
 
@@ -425,7 +424,7 @@ class PersistenceProcessorImpl
 
             public BatchPool(TSOServerCommandLineConfig config, Batch batchForTesting) {
                 emptyBatch = 0;
-                poolSize = config.getPersistHandlerNum() * NUM_BUFFERS_PER_HANDLER;
+                poolSize = config.getPersistHandlerNum() * config.getNumBuffersPerHandler();
 
                 if (batchForTesting != null) {
                     this.batchForTesting = batchForTesting;

--- a/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessorImpl.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/PersistenceProcessorImpl.java
@@ -15,76 +15,85 @@
  */
 package com.yahoo.omid.tso;
 
+import static com.codahale.metrics.MetricRegistry.name;
+import static com.yahoo.omid.tso.TSOServer.TSO_HOST_AND_PORT_KEY;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.jboss.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.lmax.disruptor.BatchEventProcessor;
+import com.lmax.disruptor.BusySpinWaitStrategy;
 import com.lmax.disruptor.EventFactory;
-import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.TimeoutBlockingWaitStrategy;
-import com.lmax.disruptor.TimeoutHandler;
+import com.lmax.disruptor.WorkHandler;
+import com.lmax.disruptor.WorkerPool;
 import com.yahoo.omid.committable.CommitTable;
 import com.yahoo.omid.metrics.Histogram;
 import com.yahoo.omid.metrics.Meter;
 import com.yahoo.omid.metrics.MetricsRegistry;
 import com.yahoo.omid.metrics.Timer;
-import org.jboss.netty.channel.Channel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import static com.codahale.metrics.MetricRegistry.name;
-import static com.yahoo.omid.tso.TSOServer.TSO_HOST_AND_PORT_KEY;
+import com.yahoo.omid.tso.PersistenceProcessorImpl.PersistEvent.Type;
+import com.yahoo.omid.tso.PersistenceProcessorImpl.PersistenceProcessorHandler.Batch;
+import com.yahoo.omid.tso.PersistenceProcessorImpl.PersistenceProcessorHandler.BatchPool;
 
 class PersistenceProcessorImpl
-        implements EventHandler<PersistenceProcessorImpl.PersistEvent>,
-        PersistenceProcessor, TimeoutHandler {
+    implements PersistenceProcessor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PersistenceProcessor.class);
-
-    static final int DEFAULT_MAX_BATCH_SIZE = 10_000;
+    static final int DEFAULT_PERSIST_HANDLER_NUM = 1;
+    static final int DEFAULT_MAX_BATCH_SIZE = 10000 / DEFAULT_PERSIST_HANDLER_NUM;
+    static final String TSO_MAX_BATCH_SIZE_KEY = "tso.maxbatchsize";
     static final int DEFAULT_BATCH_PERSIST_TIMEOUT_MS = 100;
+    static final String TSO_BATCH_PERSIST_TIMEOUT_MS_KEY = "tso.batch-persist-timeout-ms";
+    static final String TSO_PERSIST_HANDLER_NUM = "tso.persist.handler";
+    static final int NUM_BUFFERS_PER_HANDLER = 25;
 
-    private final String tsoHostAndPort;
-    private final LeaseManagement leaseManager;
     final ReplyProcessor reply;
     final RetryProcessor retryProc;
     final CommitTable.Client commitTableClient;
     final CommitTable.Writer writer;
     final Panicker panicker;
-    final RingBuffer<PersistEvent> persistRing;
+    final RingBuffer<PersistBatchEvent> persistRing;
 
+    private PersistenceProcessorHandler[] handlers;
+    private int numHandlers;
 
-    final Batch batch;
+    private BatchPool batchPool;
+    private Batch batch;
+    private long batchIDCnt;
 
-    final Timer flushTimer;
-    final Histogram batchSizeHistogram;
-    final Meter timeoutMeter;
+    private long lowWatermark;
+    MonitoringContext lowWatermarkContext;
+
     long lastFlush = System.nanoTime();
-
     final static int BATCH_TIMEOUT_MS = 100;
+
+    final Meter timeoutMeter;
 
     @Inject
     PersistenceProcessorImpl(MetricsRegistry metrics,
-                             @Named(TSO_HOST_AND_PORT_KEY) String tsoHostAndPort,
-                             LeaseManagement leaseManager,
-                             CommitTable commitTable,
-                             ReplyProcessor reply,
-                             RetryProcessor retryProc,
-                             Panicker panicker,
-                             TSOServerCommandLineConfig config)
-            throws InterruptedException, ExecutionException {
+            @Named(TSO_HOST_AND_PORT_KEY) String tsoHostAndPort,
+            LeaseManagement leaseManager,
+            CommitTable commitTable,
+            ReplyProcessor reply,
+            RetryProcessor retryProc,
+            Panicker panicker,
+            TSOServerCommandLineConfig config)
+                    throws InterruptedException, ExecutionException {
         this(metrics,
+                null,
                 tsoHostAndPort,
-                new Batch(config.getMaxBatchSize()),
                 leaseManager,
                 commitTable,
                 reply,
@@ -95,269 +104,134 @@ class PersistenceProcessorImpl
 
     @VisibleForTesting
     PersistenceProcessorImpl(MetricsRegistry metrics,
-                             String tsoHostAndPort,
                              Batch batch,
+                             String tsoHostAndPort,
                              LeaseManagement leaseManager,
                              CommitTable commitTable,
                              ReplyProcessor reply,
                              RetryProcessor retryProc,
                              Panicker panicker,
                              TSOServerCommandLineConfig config)
-            throws InterruptedException, ExecutionException {
+    throws InterruptedException, ExecutionException {
 
-        this.tsoHostAndPort = tsoHostAndPort;
-        this.batch = batch;
-        this.leaseManager = leaseManager;
         this.commitTableClient = commitTable.getClient().get();
         this.writer = commitTable.getWriter().get();
         this.reply = reply;
         this.retryProc = retryProc;
         this.panicker = panicker;
 
-        LOG.info("Creating the persist processor with batch size {}, and timeout {}ms",
-                config.getMaxBatchSize(), config.getBatchPersistTimeoutMS());
+        batchIDCnt = 0L;
 
-        flushTimer = metrics.timer(name("tso", "persist", "flush"));
-        batchSizeHistogram = metrics.histogram(name("tso", "persist", "batchsize"));
+        batchPool = new BatchPool(config, batch);
+
+        this.batch = batchPool.getNextEmptyBatch();
+
         timeoutMeter = metrics.meter(name("tso", "persist", "timeout"));
 
-        // FIXME consider putting something more like a phased strategy here to avoid
-        // all the syscalls
-        final TimeoutBlockingWaitStrategy timeoutStrategy
-                = new TimeoutBlockingWaitStrategy(config.getBatchPersistTimeoutMS(), TimeUnit.MILLISECONDS);
-
-        persistRing = RingBuffer.createSingleProducer(
-                PersistEvent.EVENT_FACTORY, 1 << 20, timeoutStrategy); // 2^20 entries in ringbuffer
+        persistRing = RingBuffer.<PersistBatchEvent>createSingleProducer(
+                PersistBatchEvent.EVENT_FACTORY, 1 << 20, new BusySpinWaitStrategy());
         SequenceBarrier persistSequenceBarrier = persistRing.newBarrier();
-        BatchEventProcessor<PersistEvent> persistProcessor = new BatchEventProcessor<PersistEvent>(
-                persistRing,
-                persistSequenceBarrier,
-                this);
-        persistRing.addGatingSequences(persistProcessor.getSequence());
-        persistProcessor.setExceptionHandler(new FatalExceptionHandler(panicker));
 
-        ExecutorService persistExec = Executors.newSingleThreadExecutor(
-                new ThreadFactoryBuilder().setNameFormat("persist-%d").build());
-        persistExec.submit(persistProcessor);
+        numHandlers = config.getPersistHandlerNum();
+        handlers = new PersistenceProcessorHandler[numHandlers];
+        for (int i = 0; i < config.getPersistHandlerNum(); i++) {
+            handlers[i] = new PersistenceProcessorHandler(metrics, tsoHostAndPort, leaseManager, commitTable, reply, retryProc, panicker, config);
+        }
+
+        WorkerPool<PersistBatchEvent> requestProcessor = new WorkerPool<PersistBatchEvent>(persistRing, persistSequenceBarrier,
+                                                            new FatalExceptionHandler(panicker), handlers);
+        persistRing.addGatingSequences(requestProcessor.getWorkerSequences());
+
+        ExecutorService requestExec = Executors.newFixedThreadPool(
+                config.getPersistHandlerNum(), new ThreadFactoryBuilder().setNameFormat("persist-%d").build());
+
+        requestProcessor.start(requestExec);
     }
 
     @Override
-    public void onEvent(PersistEvent event, long sequence, boolean endOfBatch) throws Exception {
-        switch (event.getType()) {
-            case COMMIT:
-                event.getMonCtx().timerStart("commitPersistProcessor");
-                // TODO: What happens when the IOException is thrown?
-                writer.addCommittedTransaction(event.getStartTimestamp(), event.getCommitTimestamp());
-                batch.addCommit(event.getStartTimestamp(), event.getCommitTimestamp(), event.getChannel(),
-                        event.getMonCtx());
-                break;
-            case ABORT:
-                sendAbortOrIdentifyFalsePositive(event.getStartTimestamp(), event.isRetry(), event.getChannel(),
-                        event.getMonCtx());
-                break;
-            case TIMESTAMP:
-                event.getMonCtx().timerStart("timestampPersistProcessor");
-                batch.addTimestamp(event.getStartTimestamp(), event.getChannel(), event.getMonCtx());
-                break;
-            case LOW_WATERMARK:
-                writer.updateLowWatermark(event.getLowWatermark());
-                break;
-        }
+    public void reset() {
+        batchIDCnt = 0L;
 
-        if (batch.isFull() || endOfBatch) {
-            maybeFlushBatch();
-        }
-    }
+        batchPool.reset();
+        batch = batchPool.getNextEmptyBatch();
 
-    private void sendAbortOrIdentifyFalsePositive(long startTimestamp, boolean isRetry, Channel channel,
-                                                  MonitoringContext monCtx) {
-
-        if (!isRetry) {
-            reply.abortResponse(startTimestamp, channel, monCtx);
-            return;
-        }
-
-        // If is a retry, we must check if it is a already committed request abort.
-        // This can happen because a client could have missed the reply, so it
-        // retried the request after a timeout. So we added to the batch and when
-        // it's flushed we'll add events to the retry processor in order to check
-        // for false positive aborts. It needs to be done after the flush in case
-        // the commit has occurred but it hasn't been persisted yet.
-        batch.addUndecidedRetriedRequest(startTimestamp, channel, monCtx);
-    }
-
-    // no event has been received in the timeout period
-    @Override
-    public void onTimeout(final long sequence) {
-        maybeFlushBatch();
-    }
-
-    /**
-     * Flush the current batch if it is larger than the max batch size,
-     * or BATCH_TIMEOUT_MS milliseconds have elapsed since the last flush.
-     */
-    private void maybeFlushBatch() {
-        if (batch.isFull()) {
-            flush();
-        } else if ((System.nanoTime() - lastFlush) > TimeUnit.MILLISECONDS.toNanos(BATCH_TIMEOUT_MS)) {
-            timeoutMeter.mark();
-            flush();
-        }
+        reply.reset();
     }
 
     @VisibleForTesting
-    synchronized void flush() {
+    void setBatch(Batch batch) {
+        this.batch = batch;
+    }
+
+    @Override
+    public void persistFlush(boolean forTesting) {
+        if (!forTesting && batch.getNumEvents() == 0) {
+            return;
+        }
         lastFlush = System.nanoTime();
+        batch.addLowWatermark(this.lowWatermark, this.lowWatermarkContext);
+        long seq = persistRing.next();
+        PersistBatchEvent e = persistRing.get(seq);
+        PersistBatchEvent.makePersistBatch(e, batch, batchIDCnt++);
+        persistRing.publish(seq);
 
-        boolean areWeStillMaster = true;
-        if (!leaseManager.stillInLeasePeriod()) {
-            // The master TSO replica has changed, so we must inform the
-            // clients about it when sending the replies and avoid flushing
-            // the current batch of TXs
-            areWeStillMaster = false;
-            // We need also to clear the data in the buffer
-            writer.clearWriteBuffer();
-            LOG.trace("Replica {} lost mastership before flushig data", tsoHostAndPort);
-        } else {
-            try {
-                writer.flush();
-            } catch (IOException e) {
-                panicker.panic("Error persisting commit batch", e.getCause());
-            }
-            batchSizeHistogram.update(batch.getNumEvents());
-            if (!leaseManager.stillInLeasePeriod()) {
-                // If after flushing this TSO server is not the master
-                // replica we need inform the client about it
-                areWeStillMaster = false;
-                LOG.warn("Replica {} lost mastership after flushig data", tsoHostAndPort);
-            }
-        }
-        flushTimer.update((System.nanoTime() - lastFlush));
-        batch.sendRepliesAndReset(reply, retryProc, areWeStillMaster);
-
+        batch = batchPool.getNextEmptyBatch();
     }
 
     @Override
-    public void persistCommit(long startTimestamp, long commitTimestamp, Channel c, MonitoringContext monCtx) {
-        long seq = persistRing.next();
-        PersistEvent e = persistRing.get(seq);
-        PersistEvent.makePersistCommit(e, startTimestamp, commitTimestamp, c, monCtx);
-        persistRing.publish(seq);
+    public void persistCommit(long startTimestamp, long commitTimestamp, Channel c, MonitoringContext monCtx)  {
+        batch.addCommit(startTimestamp, commitTimestamp, c, monCtx);
+        if (batch.isLastEmptyEntry()) {
+            persistFlush(false);
+        }
     }
 
     @Override
-    public void persistAbort(long startTimestamp, boolean isRetry, Channel c, MonitoringContext monCtx) {
-        long seq = persistRing.next();
-        PersistEvent e = persistRing.get(seq);
-        PersistEvent.makePersistAbort(e, startTimestamp, isRetry, c, monCtx);
-        persistRing.publish(seq);
+    public void persistAbort(long startTimestamp, boolean isRetry, Channel c, MonitoringContext context)  {
+        batch.addAbort(startTimestamp, isRetry, c, context);
+        if (batch.isLastEmptyEntry()) {
+            persistFlush(false);
+        }
     }
 
     @Override
-    public void persistTimestamp(long startTimestamp, Channel c, MonitoringContext monCtx) {
-        long seq = persistRing.next();
-        PersistEvent e = persistRing.get(seq);
-        PersistEvent.makePersistTimestamp(e, startTimestamp, c, monCtx);
-        persistRing.publish(seq);
+    public void persistTimestamp(long startTimestamp, Channel c, MonitoringContext context)  {
+        batch.addTimestamp(startTimestamp, c, context);
+        if (batch.isLastEmptyEntry()) {
+            persistFlush(false);
+        }
     }
 
     @Override
-    public void persistLowWatermark(long lowWatermark) {
-        long seq = persistRing.next();
-        PersistEvent e = persistRing.get(seq);
-        PersistEvent.makePersistLowWatermark(e, lowWatermark);
-        persistRing.publish(seq);
+    public void persistLowWatermark(long lowWatermark, MonitoringContext context) {
+        this.lowWatermark = lowWatermark;
+        this.lowWatermarkContext = context;
     }
 
-    public static class Batch {
+    public final static class PersistBatchEvent {
+        Batch batch;
+        long batchID;
 
-        final PersistEvent[] events;
-        final int maxBatchSize;
-        int numEvents;
+        static void makePersistBatch(PersistBatchEvent e, Batch batch, long batchID) {
+            e.batch = batch;
+            e.batchID = batchID;
+        }
 
-        Batch(int maxBatchSize) {
-            assert (maxBatchSize > 0);
-            this.maxBatchSize = maxBatchSize;
-            events = new PersistEvent[maxBatchSize];
-            numEvents = 0;
-            for (int i = 0; i < maxBatchSize; i++) {
-                events[i] = new PersistEvent();
+        Batch getBatch() {
+            return batch;
+        }
+
+        long getBatchID() {
+            return batchID;
+        }
+
+        public final static EventFactory<PersistBatchEvent> EVENT_FACTORY
+        = new EventFactory<PersistBatchEvent>() {
+            public PersistBatchEvent newInstance() {
+                return new PersistBatchEvent();
             }
-        }
 
-        boolean isFull() {
-            assert (numEvents <= maxBatchSize);
-            return numEvents == maxBatchSize;
-        }
-
-        int getNumEvents() {
-            return numEvents;
-        }
-
-        void addCommit(long startTimestamp, long commitTimestamp, Channel c, MonitoringContext monCtx) {
-            if (isFull()) {
-                throw new IllegalStateException("batch full");
-            }
-            int index = numEvents++;
-            PersistEvent e = events[index];
-            PersistEvent.makePersistCommit(e, startTimestamp, commitTimestamp, c, monCtx);
-        }
-
-        void addUndecidedRetriedRequest(long startTimestamp, Channel c, MonitoringContext monCtx) {
-            if (isFull()) {
-                throw new IllegalStateException("batch full");
-            }
-            int index = numEvents++;
-            PersistEvent e = events[index];
-            // We mark the event as an ABORT retry to identify the events to send
-            // to the retry processor
-            PersistEvent.makePersistAbort(e, startTimestamp, true, c, monCtx);
-        }
-
-        void addTimestamp(long startTimestamp, Channel c, MonitoringContext monCtx) {
-            if (isFull()) {
-                throw new IllegalStateException("batch full");
-            }
-            int index = numEvents++;
-            PersistEvent e = events[index];
-            PersistEvent.makePersistTimestamp(e, startTimestamp, c, monCtx);
-        }
-
-        void sendRepliesAndReset(ReplyProcessor reply, RetryProcessor retryProc, boolean isTSOInstanceMaster) {
-            for (int i = 0; i < numEvents; i++) {
-                PersistEvent e = events[i];
-                switch (e.getType()) {
-                    case TIMESTAMP:
-                        e.getMonCtx().timerStop("timestampPersistProcessor");
-                        reply.timestampResponse(e.getStartTimestamp(), e.getChannel(), e.getMonCtx());
-                        break;
-                    case COMMIT:
-                        e.getMonCtx().timerStop("commitPersistProcessor");
-                        if (isTSOInstanceMaster) {
-                            reply.commitResponse(false, e.getStartTimestamp(), e.getCommitTimestamp(), e.getChannel(),
-                                    e.getMonCtx());
-                        } else {
-                            // The client will need to perform heuristic actions to determine the output
-                            reply.commitResponse(true, e.getStartTimestamp(), e.getCommitTimestamp(), e.getChannel(),
-                                    e.getMonCtx());
-                        }
-                        break;
-                    case ABORT:
-                        if (e.isRetry()) {
-                            retryProc.disambiguateRetryRequestHeuristically(e.getStartTimestamp(), e.getChannel(),
-                                    e.getMonCtx());
-                        } else {
-                            LOG.error("We should not be receiving non-retried aborted requests in here");
-                        }
-                        break;
-                    default:
-                        LOG.error("We should receive only COMMIT or ABORT event types. Received {}", e.getType());
-                        break;
-                }
-            }
-            numEvents = 0;
-        }
-
+        };
     }
 
     public final static class PersistEvent {
@@ -367,14 +241,13 @@ class PersistenceProcessorImpl
         enum Type {
             TIMESTAMP, COMMIT, ABORT, LOW_WATERMARK
         }
-
         private Type type = null;
         private Channel channel = null;
 
         private boolean isRetry = false;
-        private long startTimestamp = 0;
-        private long commitTimestamp = 0;
-        private long lowWatermark;
+        private long startTimestamp = 0L;
+        private long commitTimestamp = 0L;
+        private long lowWatermark = 0L;
 
         static void makePersistCommit(PersistEvent e, long startTimestamp, long commitTimestamp, Channel c,
                                       MonitoringContext monCtx) {
@@ -394,17 +267,17 @@ class PersistenceProcessorImpl
             e.monCtx = monCtx;
         }
 
-        static void makePersistTimestamp(PersistEvent e, long startTimestamp, Channel c,
-                                         MonitoringContext monCtx) {
+        static void makePersistTimestamp(PersistEvent e, long startTimestamp, Channel c, MonitoringContext monCtx) {
             e.type = Type.TIMESTAMP;
             e.startTimestamp = startTimestamp;
             e.channel = c;
             e.monCtx = monCtx;
         }
 
-        static void makePersistLowWatermark(PersistEvent e, long lowWatermark) {
+        static void makePersistLowWatermark(PersistEvent e, long lowWatermark, MonitoringContext monCtx) {
             e.type = Type.LOW_WATERMARK;
             e.lowWatermark = lowWatermark;
+            e.monCtx = monCtx;
         }
 
         MonitoringContext getMonCtx() {
@@ -434,14 +307,257 @@ class PersistenceProcessorImpl
         long getLowWatermark() {
             return lowWatermark;
         }
-
-        public final static EventFactory<PersistEvent> EVENT_FACTORY
-                = new EventFactory<PersistEvent>() {
-            @Override
-            public PersistEvent newInstance() {
-                return new PersistEvent();
-            }
-        };
     }
 
+    static class PersistenceProcessorHandler
+    implements
+    WorkHandler<PersistenceProcessorImpl.PersistBatchEvent> {
+
+        private static final Logger LOG = LoggerFactory.getLogger(PersistenceProcessor.class);
+
+        private final String tsoHostAndPort;
+        private final LeaseManagement leaseManager;
+
+        final ReplyProcessor reply;
+        final RetryProcessor retryProc;
+        final CommitTable.Client commitTableClient;
+        final CommitTable.Writer writer;
+        final Panicker panicker;
+
+        final int maxBatchSize;
+
+        Batch handlerBatch;
+
+        final Timer flushTimer;
+        final Histogram batchSizeHistogram;
+
+        long lastFlush;
+
+        PersistenceProcessorHandler(MetricsRegistry metrics,
+                String tsoHostAndPort,
+                LeaseManagement leaseManager,
+                CommitTable commitTable,
+                ReplyProcessor reply,
+                RetryProcessor retryProc,
+                Panicker panicker,
+                TSOServerCommandLineConfig config)
+                        throws InterruptedException, ExecutionException {
+
+            this.tsoHostAndPort = tsoHostAndPort;
+            this.leaseManager = leaseManager;
+            this.commitTableClient = commitTable.getClient().get();
+            this.writer = commitTable.getWriter().get();
+            this.reply = reply;
+            this.retryProc = retryProc;
+            this.panicker = panicker;
+            this.maxBatchSize = config.getMaxBatchSize();
+
+            LOG.info("Creating the persist processor with batch size {}, and timeout {}ms",
+                    maxBatchSize, config.getBatchPersistTimeoutMS());
+
+            flushTimer = metrics.timer(name("tso", "persist", "flush"));
+            batchSizeHistogram = metrics.histogram(name("tso", "persist", "batchsize"));
+        }
+
+        @Override
+        public void onEvent(PersistenceProcessorImpl.PersistBatchEvent event) throws Exception {
+            Batch batch = event.getBatch();
+            handlerBatch = batch;
+            for (int i=0; i < batch.getNumEvents(); ++i) {
+                PersistenceProcessorImpl.PersistEvent localEvent = batch.events[i];
+
+                switch (localEvent.getType()) {
+                case COMMIT:
+                    localEvent.getMonCtx().timerStart("commitPersistProcessor");
+                    // TODO: What happens when the IOException is thrown?
+                    writer.addCommittedTransaction(localEvent.getStartTimestamp(), localEvent.getCommitTimestamp());
+                    break;
+                case ABORT:
+                    break;
+                case TIMESTAMP:
+                    localEvent.getMonCtx().timerStart("timestampPersistProcessor");
+                    break;
+                case LOW_WATERMARK:
+                    writer.updateLowWatermark(localEvent.getLowWatermark());
+                    break;
+                default:
+                    assert(false);
+                }
+            }
+            flush(event.getBatchID());
+        }
+
+        private void flush(long batchID) throws IOException {
+            lastFlush = System.nanoTime();
+
+            boolean areWeStillMaster = true;
+            if (!leaseManager.stillInLeasePeriod()) {
+                // The master TSO replica has changed, so we must inform the
+                // clients about it when sending the replies and avoid flushing
+                // the current batch of TXs
+                areWeStillMaster = false;
+                // We need also to clear the data in the buffer
+                writer.clearWriteBuffer();
+                LOG.trace("Replica {} lost mastership before flushig data", tsoHostAndPort);
+            } else {
+                try {
+                    writer.flush();
+                } catch (IOException e) {
+                    panicker.panic("Error persisting commit batch", e.getCause());
+                }
+                batchSizeHistogram.update(handlerBatch.getNumEvents());
+                if (!leaseManager.stillInLeasePeriod()) {
+                    // If after flushing this TSO server is not the master
+                    // replica we need inform the client about it
+                    areWeStillMaster = false;
+                    LOG.warn("Replica {} lost mastership after flushig data", tsoHostAndPort);
+                }
+            }
+            flushTimer.update((System.nanoTime() - lastFlush));
+            handlerBatch.sendReply(reply, retryProc, batchID, areWeStillMaster);
+        }
+
+        public static class BatchPool {
+            private Batch batchForTesting;
+            private Batch[] batches;
+            private int emptyBatch;
+            private int poolSize;
+
+            public BatchPool(TSOServerCommandLineConfig config, Batch batchForTesting) {
+                emptyBatch = 0;
+                poolSize = config.getPersistHandlerNum() * NUM_BUFFERS_PER_HANDLER;
+
+                if (batchForTesting != null) {
+                    this.batchForTesting = batchForTesting;
+                } else {
+                    batches = new Batch[poolSize];
+                    for (int i=0; i < poolSize; ++i) {
+                        batches[i] = new Batch(config.getMaxBatchSize(), i);
+                    }
+                }
+            }
+
+            public Batch getNextEmptyBatch() {
+                if (batchForTesting != null) {
+                    return batchForTesting;
+                } else {
+                    for (;batches[emptyBatch].getNumEvents() != 0; emptyBatch = (emptyBatch + 1) % (poolSize));
+                    return batches[emptyBatch];
+                }
+            }
+
+            public void reset() {
+                for (int i=0; i < poolSize; ++i) {
+                    batches[i].clear();
+                }
+                emptyBatch = 0;
+            }
+        }
+
+        public static class Batch {
+            final PersistEvent[] events;
+            final int maxBatchSize;
+            int numEvents;
+            int id;
+
+            Batch(int maxBatchSize, int id) {
+                assert (maxBatchSize > 0);
+                this.maxBatchSize = maxBatchSize;
+                events = new PersistEvent[maxBatchSize];
+                numEvents = 0;
+                for (int i = 0; i < maxBatchSize; i++) {
+                    events[i] = new PersistEvent();
+                }
+                this.id = id;
+            }
+
+            int getID() {
+                return id;
+            }
+
+            boolean isFull() {
+                assert (numEvents <= maxBatchSize);
+                return numEvents == maxBatchSize;
+            }
+
+            boolean isLastEmptyEntry() {
+                assert (numEvents <= maxBatchSize);
+                return numEvents == (maxBatchSize - 1);
+            }
+
+            int getNumEvents() {
+                return numEvents;
+            }
+
+            void clear() {
+                numEvents = 0;
+            }
+
+            void addCommit(long startTimestamp, long commitTimestamp, Channel c, MonitoringContext context) {
+                if (isFull()) {
+                    throw new IllegalStateException("batch full");
+                }
+                int index = numEvents++;
+                PersistEvent e = events[index];
+                PersistEvent.makePersistCommit(e, startTimestamp, commitTimestamp, c, context);
+            }
+
+            void addAbort(long startTimestamp, boolean isRetry, Channel c, MonitoringContext context) {
+                if (isFull()) {
+                    throw new IllegalStateException("batch full");
+                }
+                int index = numEvents++;
+                PersistEvent e = events[index];
+                PersistEvent.makePersistAbort(e, startTimestamp, isRetry, c, context);
+            }
+
+            void addUndecidedRetriedRequest(long startTimestamp, Channel c, MonitoringContext context) {
+                if (isFull()) {
+                    throw new IllegalStateException("batch full");
+                }
+                int index = numEvents++;
+                PersistEvent e = events[index];
+                // We mark the event as an ABORT retry to identify the events to send
+                // to the retry processor
+                PersistEvent.makePersistAbort(e, startTimestamp, true, c, context);
+            }
+
+            void addTimestamp(long startTimestamp, Channel c, MonitoringContext context) {
+                if (isFull()) {
+                    throw new IllegalStateException("batch full");
+                }
+                int index = numEvents++;
+                PersistEvent e = events[index];
+                PersistEvent.makePersistTimestamp(e, startTimestamp, c, context);
+            }
+
+            void addLowWatermark(long lowWatermark, MonitoringContext context) {
+                if (isFull()) {
+                    throw new IllegalStateException("batch full");
+                }
+                int index = numEvents++;
+                PersistEvent e = events[index];
+                PersistEvent.makePersistLowWatermark(e, lowWatermark, context);
+            }
+
+            void sendReply(ReplyProcessor reply, RetryProcessor retryProc, long batchID, boolean isTSOInstanceMaster) {
+                for (int i = 0; i < numEvents;) {
+                    PersistEvent e = events[i];
+                    if (e.getType() == Type.ABORT && e.isRetry()) {
+                        retryProc.disambiguateRetryRequestHeuristically(e.getStartTimestamp(), e.getChannel(), e.getMonCtx());
+                        events[i] = events[numEvents - 1];
+                        if (numEvents == 1) {
+                            numEvents = 0;
+                            break;
+                        }
+                        --numEvents;
+                        continue;
+                    }
+                    ++i;
+                }
+
+                reply.batchResponse(this, batchID, !isTSOInstanceMaster);
+            }
+        }
+    }
 }

--- a/tso-server/src/main/java/com/yahoo/omid/tso/ReplyProcessor.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/ReplyProcessor.java
@@ -17,12 +17,19 @@ package com.yahoo.omid.tso;
 
 import org.jboss.netty.channel.Channel;
 
-interface ReplyProcessor {
+import com.yahoo.omid.tso.PersistenceProcessorImpl.PersistenceProcessorHandler.Batch;
+
+interface ReplyProcessor
+{
     /**
      * Informs the client about the outcome of the Tx it was trying to
      * commit. If the heuristic decision flat is enabled, the client
      * will need to do additional actions for learning the final outcome.
      *
+     * @param batch
+     *            the batch of operations
+     * @param batchID
+     *            the id of the batch, used to enforce order between replies
      * @param makeHeuristicDecision
      *            informs about whether heuristic actions are needed or not
      * @param startTimestamp
@@ -32,10 +39,9 @@ interface ReplyProcessor {
      * @param channel
      *            the communication channed with the client
      */
-    void commitResponse(boolean makeHeuristicDecision, long startTimestamp, long commitTimestamp, Channel channel, MonitoringContext monCtx);
-
-    void abortResponse(long startTimestamp, Channel c, MonitoringContext monCtx);
-
-    void timestampResponse(long startTimestamp, Channel c, MonitoringContext monCtx);
+    void batchResponse(Batch batch, long batchID, boolean makeHeuristicDecision);
+    void addAbort(Batch batch, long startTimestamp, Channel c, MonitoringContext context);
+    void addCommit(Batch batch, long startTimestamp, long commitTimestamp, Channel c, MonitoringContext context);
+    void reset();
 }
 

--- a/tso-server/src/main/java/com/yahoo/omid/tso/ReplyProcessorImpl.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/ReplyProcessorImpl.java
@@ -87,7 +87,6 @@ class ReplyProcessorImpl implements EventHandler<ReplyProcessorImpl.ReplyBatchEv
 
     private void handleReplyBatchEvent(ReplyBatchEvent event) {
         String name = null;
-
         Batch batch = event.getBatch();
         for (int i=0; i < batch.getNumEvents(); ++i) {
             PersistenceProcessorImpl.PersistEvent localEvent = batch.events[i];
@@ -209,7 +208,6 @@ class ReplyProcessorImpl implements EventHandler<ReplyProcessorImpl.ReplyBatchEv
 
         timestampMeter.mark();
     }
-
 
     public final static class ReplyBatchEvent {
         Batch batch;

--- a/tso-server/src/main/java/com/yahoo/omid/tso/TSOServerCommandLineConfig.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/TSOServerCommandLineConfig.java
@@ -40,6 +40,7 @@ import static com.yahoo.omid.tso.PersistenceProcessorImpl.DEFAULT_BATCH_PERSIST_
 import static com.yahoo.omid.tso.PersistenceProcessorImpl.DEFAULT_PERSIST_HANDLER_NUM;
 import static com.yahoo.omid.tso.PersistenceProcessorImpl.DEFAULT_MAX_BATCH_SIZE;
 import static com.yahoo.omid.tso.RequestProcessorImpl.DEFAULT_MAX_ITEMS;
+import static com.yahoo.omid.tso.PersistenceProcessorImpl.NUM_BUFFERS_PER_HANDLER;
 
 /**
  * Holds the configuration parameters of a TSO server instance.
@@ -149,7 +150,10 @@ public class TSOServerCommandLineConfig extends JCommander implements IVariableA
 
     @Parameter(names = "-persistHandlerNum", description = "Number of handlers that writes to the commit table")
     private int persistHandlerNum = DEFAULT_PERSIST_HANDLER_NUM;
-    
+
+    @Parameter(names = "-numBuffersPerHandler", description = "The number of buffers allocated for each persist processor handler.")
+    private int numBuffersPerHandler = NUM_BUFFERS_PER_HANDLER;
+
     // TODO This is probably going to be temporary. So, we should remove it later if not required. Otherwise
     // we should make it private and provide accessors as is done with the other parameters
     @Parameter(names = "-publishHostAndPortInZK", description = "Publishes the host:port of this TSO server in ZK")
@@ -237,6 +241,10 @@ public class TSOServerCommandLineConfig extends JCommander implements IVariableA
 
     public int getPersistHandlerNum() {
         return persistHandlerNum;
+    }
+
+    public int getNumBuffersPerHandler() {
+        return numBuffersPerHandler;
     }
 
     public HBaseLogin.Config getLoginFlags() {

--- a/tso-server/src/main/java/com/yahoo/omid/tso/TSOServerCommandLineConfig.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/TSOServerCommandLineConfig.java
@@ -37,6 +37,7 @@ import static com.yahoo.omid.committable.hbase.CommitTableConstants.COMMIT_TABLE
 import static com.yahoo.omid.timestamp.storage.HBaseTimestampStorage.TIMESTAMP_TABLE_DEFAULT_NAME;
 import static com.yahoo.omid.timestamp.storage.ZKTimestampStorage.DEFAULT_ZK_CLUSTER;
 import static com.yahoo.omid.tso.PersistenceProcessorImpl.DEFAULT_BATCH_PERSIST_TIMEOUT_MS;
+import static com.yahoo.omid.tso.PersistenceProcessorImpl.DEFAULT_PERSIST_HANDLER_NUM;
 import static com.yahoo.omid.tso.PersistenceProcessorImpl.DEFAULT_MAX_BATCH_SIZE;
 import static com.yahoo.omid.tso.RequestProcessorImpl.DEFAULT_MAX_ITEMS;
 
@@ -146,6 +147,9 @@ public class TSOServerCommandLineConfig extends JCommander implements IVariableA
     @Parameter(names = "-batchPersistTimeout", description = "Number of milliseconds the persist processer will wait without new input before flushing a batch")
     private int batchPersistTimeoutMS = DEFAULT_BATCH_PERSIST_TIMEOUT_MS;
 
+    @Parameter(names = "-persistHandlerNum", description = "Number of handlers that writes to the commit table")
+    private int persistHandlerNum = DEFAULT_PERSIST_HANDLER_NUM;
+    
     // TODO This is probably going to be temporary. So, we should remove it later if not required. Otherwise
     // we should make it private and provide accessors as is done with the other parameters
     @Parameter(names = "-publishHostAndPortInZK", description = "Publishes the host:port of this TSO server in ZK")
@@ -229,6 +233,10 @@ public class TSOServerCommandLineConfig extends JCommander implements IVariableA
 
     public int getBatchPersistTimeoutMS() {
         return batchPersistTimeoutMS;
+    }
+
+    public int getPersistHandlerNum() {
+        return persistHandlerNum;
     }
 
     public HBaseLogin.Config getLoginFlags() {

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestPanicker.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestPanicker.java
@@ -111,6 +111,9 @@ public class TestPanicker {
                 panicker,
                 TSOServerCommandLineConfig.defaultConfig());
         proc.persistCommit(1, 2, null, new MonitoringContext(metrics));
+
+        new RequestProcessorImpl(metrics, mock(TimestampOracle.class), proc, panicker, mock(TSOServerCommandLineConfig.class));
+
         verify(panicker, timeout(1000).atLeastOnce()).panic(anyString(), any(Throwable.class));
     }
 
@@ -149,6 +152,9 @@ public class TestPanicker {
                 panicker,
                 TSOServerCommandLineConfig.defaultConfig());
         proc.persistCommit(1, 2, null, new MonitoringContext(metrics));
+
+        new RequestProcessorImpl(metrics, mock(TimestampOracle.class), proc, panicker, mock(TSOServerCommandLineConfig.class));
+
         verify(panicker, timeout(1000).atLeastOnce()).panic(anyString(), any(Throwable.class));
     }
 }

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestPersistenceProcessor.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestPersistenceProcessor.java
@@ -200,7 +200,7 @@ public class TestPersistenceProcessor {
     }
 
     @Test
-    public void testCommitPersistenceWithHALeaseManager() throws Exception {
+    public void testCommitPersistenceWithHALeaseManagerMultiHandlers() throws Exception {
         String[] configArgs = new String[]{"-persistHandlerNum", "4"};
         TSOServerCommandLineConfig tsoConfig = TSOServerCommandLineConfig.parseConfig(configArgs);
 
@@ -208,7 +208,7 @@ public class TestPersistenceProcessor {
     }
 
     @Test
-    public void testCommitPersistenceWithHALeaseManagerMultiHandlers() throws Exception {
+    public void testCommitPersistenceWithHALeaseManager() throws Exception {
         testCommitPersistenceWithHALeaseManagerPerConfig(TSOServerCommandLineConfig.defaultConfig());
     }
 
@@ -235,7 +235,7 @@ public class TestPersistenceProcessor {
         proc.persistCommit(1, 2, null, monCtx);
         proc.persistFlush(true);
         verify(leaseManager, timeout(1000).times(2)).stillInLeasePeriod();
-        verify(batch).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(true));
+        verify(batch, timeout(1000).times(1)).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(true));
 
         // Configure the lease manager to always return true first and false
         // later for stillInLeasePeriod, so verify the batch sends replies as
@@ -247,7 +247,7 @@ public class TestPersistenceProcessor {
         proc.persistCommit(1, 2, null, monCtx);
         proc.persistFlush(true);
         verify(leaseManager, timeout(1000).times(2)).stillInLeasePeriod();
-        verify(batch).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(false));
+        verify(batch, timeout(1000).times(1)).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(false));
 
         // Configure the lease manager to always return false for
         // stillInLeasePeriod, so verify the batch sends replies as non-master

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestPersistenceProcessor.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestPersistenceProcessor.java
@@ -5,7 +5,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.yahoo.omid.committable.CommitTable;
 import com.yahoo.omid.metrics.MetricsRegistry;
 import com.yahoo.omid.metrics.NullMetricsProvider;
-import com.yahoo.omid.tso.PersistenceProcessorImpl.Batch;
+import com.yahoo.omid.tso.PersistenceProcessorImpl.PersistenceProcessorHandler.Batch;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -91,23 +91,24 @@ public class TestPersistenceProcessor {
                 mock(TSOStateManager.class)));
         // Component under test
         PersistenceProcessor proc = new PersistenceProcessorImpl(metrics,
-                "localhost:1234",
-                batch,
-                leaseManager,
-                commitTable,
-                replyProcessor,
-                retryProcessor,
-                panicker,
-                TSOServerCommandLineConfig.defaultConfig());
+                                                                 batch,
+                                                                 "localhost:1234",
+                                                                 leaseManager,
+                                                                 commitTable,
+                                                                 replyProcessor,
+                                                                 retryProcessor,
+                                                                 panicker,
+                                                                 TSOServerCommandLineConfig.defaultConfig());
 
         // The non-ha lease manager always return true for
         // stillInLeasePeriod(), so verify the batch sends replies as master
         MonitoringContext monCtx = new MonitoringContext(metrics);
         proc.persistCommit(1, 2, null, monCtx);
+        proc.persistFlush(true);
         verify(leaseManager, timeout(1000).times(2)).stillInLeasePeriod();
-        verify(batch, timeout(1000).times(2)).sendRepliesAndReset(any(ReplyProcessor.class),
-                any(RetryProcessor.class),
-                eq(true));
+        verify(batch, timeout(1000).times(1)).sendReply(any(ReplyProcessor.class),
+                                                        any(RetryProcessor.class),
+                                                        any(Long.class), eq(true));
     }
 
     @Test
@@ -116,42 +117,47 @@ public class TestPersistenceProcessor {
         // Init a HA lease manager
         LeaseManager leaseManager = mock(LeaseManager.class);
         // Component under test
-        PersistenceProcessor proc = new PersistenceProcessorImpl(metrics,
-                "localhost:1234",
-                batch,
-                leaseManager,
-                commitTable,
-                replyProcessor,
-                retryProcessor,
-                panicker,
-                TSOServerCommandLineConfig.defaultConfig());
+        PersistenceProcessorImpl proc = new PersistenceProcessorImpl(metrics,
+                                                                 batch,
+                                                                 "localhost:1234",
+                                                                 leaseManager,
+                                                                 commitTable,
+                                                                 replyProcessor,
+                                                                 retryProcessor,
+                                                                 panicker,
+                                                                 TSOServerCommandLineConfig.defaultConfig());
 
         // Configure the lease manager to always return true for
         // stillInLeasePeriod, so verify the batch sends replies as master
         doReturn(true).when(leaseManager).stillInLeasePeriod();
         MonitoringContext monCtx = new MonitoringContext(metrics);
         proc.persistCommit(1, 2, null, monCtx);
+        proc.persistFlush(true);
         verify(leaseManager, timeout(1000).times(2)).stillInLeasePeriod();
-        verify(batch).sendRepliesAndReset(any(ReplyProcessor.class), any(RetryProcessor.class), eq(true));
+        verify(batch).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(true));
 
         // Configure the lease manager to always return true first and false
         // later for stillInLeasePeriod, so verify the batch sends replies as
         // non-master
         reset(leaseManager);
         reset(batch);
+        proc.setBatch(batch);
         doReturn(true).doReturn(false).when(leaseManager).stillInLeasePeriod();
         proc.persistCommit(1, 2, null, monCtx);
+        proc.persistFlush(true);
         verify(leaseManager, timeout(1000).times(2)).stillInLeasePeriod();
-        verify(batch).sendRepliesAndReset(any(ReplyProcessor.class), any(RetryProcessor.class), eq(false));
+        verify(batch).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(false));
 
         // Configure the lease manager to always return false for
         // stillInLeasePeriod, so verify the batch sends replies as non-master
         reset(leaseManager);
         reset(batch);
+        proc.setBatch(batch);
         doReturn(false).when(leaseManager).stillInLeasePeriod();
         proc.persistCommit(1, 2, null, monCtx);
+        proc.persistFlush(true);
         verify(leaseManager, timeout(1000).times(1)).stillInLeasePeriod();
-        verify(batch).sendRepliesAndReset(any(ReplyProcessor.class), any(RetryProcessor.class), eq(false));
+        verify(batch, timeout(1000).times(1)).sendReply(any(ReplyProcessor.class), any(RetryProcessor.class), any(Long.class), eq(false));
     }
 
     @Test
@@ -178,6 +184,7 @@ public class TestPersistenceProcessor {
 
         // Check the panic is extended!
         proc.persistCommit(1, 2, null, monCtx);
+        proc.persistFlush(true);
         verify(panicker, timeout(1000).atLeastOnce()).panic(anyString(), any(Throwable.class));
     }
 
@@ -199,6 +206,7 @@ public class TestPersistenceProcessor {
 
         // Check the panic is extended!
         proc.persistCommit(1, 2, null, monCtx);
+        proc.persistFlush(true);
         verify(panicker, timeout(1000).atLeastOnce()).panic(anyString(), any(Throwable.class));
     }
 

--- a/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestTSOClientRequestAndResponseBehaviours.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestTSOClientRequestAndResponseBehaviours.java
@@ -67,7 +67,7 @@ public class TestTSOClientRequestAndResponseBehaviours {
     @BeforeClass
     public void setup() throws Exception {
 
-        String[] configArgs = new String[]{"-port", Integer.toString(TSO_SERVER_PORT), "-maxItems", "1000"};
+        String[] configArgs = new String[]{"-port", Integer.toString(TSO_SERVER_PORT), "-maxItems", "1000", "-numBuffersPerHandler", "50"};
         TSOServerCommandLineConfig tsoConfig = TSOServerCommandLineConfig.parseConfig(configArgs);
         Module tsoServerMockModule = new TSOMockModule(tsoConfig);
         Injector injector = Guice.createInjector(tsoServerMockModule);


### PR DESCRIPTION
Scaling up the TSO by parallelizing the batched writes to the commit table. The architecture mostly changed by adding batch events and creating handlers under PersistenceProcessorImpl.
This commit increases the performance of Omid from 55K tps to 380K tps when using 6 region servers.
Please note that the addition of MonitoringContext significantly degrades performance and therefore, should becomes optional to achieve good performance.