### PR TITLE
Allow async shadow cell update

### DIFF
--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -64,13 +64,15 @@
 
         <!-- end storage related -->
 
-        <!--logging-->
+        <!-- logging -->
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+
+        <!-- end logging -->
 
         <!-- testing -->
 

--- a/hbase-client/src/main/java/com/yahoo/omid/transaction/HBaseAsyncPostCommitter.java
+++ b/hbase-client/src/main/java/com/yahoo/omid/transaction/HBaseAsyncPostCommitter.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2011-2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.omid.transaction;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.yahoo.omid.tsoclient.CellId;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class HBaseAsyncPostCommitter implements PostCommitActions {
+
+    private PostCommitActions syncPostCommitExecutor;
+
+    ExecutorService postCommitExecutor =
+            Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("postCommit-%d").build());
+
+    public HBaseAsyncPostCommitter(PostCommitActions postCommitExecutor) {
+        syncPostCommitExecutor = postCommitExecutor;
+    }
+
+    @Override
+    public void updateShadowCells(final AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException
+    {
+        postCommitExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    syncPostCommitExecutor.updateShadowCells(transaction);
+                } catch (TransactionManagerException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void removeCommitTableEntry(final AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException
+    {
+        postCommitExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    syncPostCommitExecutor.removeCommitTableEntry(transaction);
+                } catch (TransactionManagerException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void updateShadowCellsAndRemoveCommitTableEntry(final AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException
+    {
+        postCommitExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    syncPostCommitExecutor.updateShadowCells(transaction);
+                    syncPostCommitExecutor.removeCommitTableEntry(transaction);
+                } catch (TransactionManagerException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+}

--- a/hbase-client/src/main/java/com/yahoo/omid/transaction/HBaseSyncPostCommitter.java
+++ b/hbase-client/src/main/java/com/yahoo/omid/transaction/HBaseSyncPostCommitter.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2011-2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.omid.transaction;
+
+import com.yahoo.omid.committable.CommitTable;
+import com.yahoo.omid.metrics.MetricsRegistry;
+import com.yahoo.omid.metrics.Timer;
+import com.yahoo.omid.tsoclient.CellId;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static com.yahoo.omid.metrics.MetricsUtils.name;
+
+public class HBaseSyncPostCommitter implements PostCommitActions {
+
+    private final MetricsRegistry metrics;
+    private final CommitTable.Client commitTableClient;
+
+    private final Timer commitTableUpdateTimer;
+    private final Timer shadowCellsUpdateTimer;
+
+    public HBaseSyncPostCommitter(MetricsRegistry metrics, CommitTable.Client commitTableClient) {
+        this.metrics = metrics;
+        this.commitTableClient = commitTableClient;
+
+        this.commitTableUpdateTimer = metrics.timer(name("omid", "tm", "hbase", "commitTableUpdate", "latency"));
+        this.shadowCellsUpdateTimer = metrics.timer(name("omid", "tm", "hbase", "shadowCellsUpdate", "latency"));
+    }
+
+    @Override
+    public void updateShadowCells(AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException
+    {
+
+        HBaseTransaction tx = HBaseTransactionManager.enforceHBaseTransactionAsParam(transaction);
+
+        shadowCellsUpdateTimer.start();
+        try {
+
+            // Add shadow cells
+            for (HBaseCellId cell : tx.getWriteSet()) {
+                Put put = new Put(cell.getRow());
+                put.add(cell.getFamily(),
+                        CellUtils.addShadowCellSuffix(cell.getQualifier(), 0, cell.getQualifier().length),
+                        tx.getStartTimestamp(),
+                        Bytes.toBytes(tx.getCommitTimestamp()));
+                try {
+                    cell.getTable().put(put);
+                } catch (IOException e) {
+                    throw new TransactionManagerException(tx + ": Error inserting shadow cell " + cell, e);
+                }
+            }
+
+            // Flush affected tables before returning to avoid loss of shadow cells updates when autoflush is disabled
+            try {
+                tx.flushTables();
+            } catch (IOException e) {
+                throw new TransactionManagerException(tx + ": Error while flushing writes", e);
+            }
+
+        } finally {
+            shadowCellsUpdateTimer.stop();
+        }
+
+    }
+
+    @Override
+    public void removeCommitTableEntry(AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException
+    {
+
+        HBaseTransaction tx = HBaseTransactionManager.enforceHBaseTransactionAsParam(transaction);
+
+        commitTableUpdateTimer.start();
+
+        try {
+            commitTableClient.completeTransaction(tx.getStartTimestamp()).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new TransactionManagerException(tx + ": interrupted during commit table entry delete");
+        } catch (ExecutionException e) {
+            throw new TransactionManagerException(tx + ": can't remove commit table entry");
+        } finally {
+            commitTableUpdateTimer.start();
+        }
+
+    }
+
+    @Override
+    public void updateShadowCellsAndRemoveCommitTableEntry(AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException
+    {
+        updateShadowCells(transaction);
+        removeCommitTableEntry(transaction);
+    }
+
+}

--- a/hbase-client/src/test/java/com/yahoo/omid/transaction/OmidTestBase.java
+++ b/hbase-client/src/test/java/com/yahoo/omid/transaction/OmidTestBase.java
@@ -152,6 +152,15 @@ public abstract class OmidTestBase {
         return newTransactionManager(context, getClient(context));
     }
 
+    protected TransactionManager newTransactionManager(ITestContext context, PostCommitActions postCommitActions) throws Exception {
+        return HBaseTransactionManager.newBuilder()
+                .withConfiguration(hbaseConf)
+                .withCommitTableClient(getCommitTable(context).getClient())
+                .withTSOClient(getClient(context))
+                .postCommitter(postCommitActions)
+                .build();
+    }
+
     protected TransactionManager newTransactionManager(ITestContext context, TSOClient tsoClient) throws Exception {
         return HBaseTransactionManager.newBuilder()
                 .withConfiguration(hbaseConf)

--- a/hbase-client/src/test/java/com/yahoo/omid/transaction/TestAsynchronousPostCommitter.java
+++ b/hbase-client/src/test/java/com/yahoo/omid/transaction/TestAsynchronousPostCommitter.java
@@ -1,0 +1,249 @@
+package com.yahoo.omid.transaction;
+
+import com.google.common.base.Optional;
+import com.yahoo.omid.committable.CommitTable;
+import com.yahoo.omid.metrics.NullMetricsProvider;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.ITestContext;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "sharedHBase")
+public class TestAsynchronousPostCommitter extends OmidTestBase {
+
+    private static final byte[] family = Bytes.toBytes(TEST_FAMILY);
+    private static final byte[] nonExistentFamily = Bytes.toBytes("non-existent");
+    private static final byte[] qualifier = Bytes.toBytes("test-qual");
+
+    byte[] row1 = Bytes.toBytes("test-is-committed1");
+    byte[] row2 = Bytes.toBytes("test-is-committed2");
+
+    @Test(timeOut = 30_000)
+    public void testPostCommitActionsAreCalledAsynchronously(ITestContext context) throws Exception {
+
+        CommitTable.Client commitTableClient = getCommitTable(context).getClient();
+
+        PostCommitActions syncPostCommitter =
+                spy(new HBaseSyncPostCommitter(new NullMetricsProvider(), commitTableClient));
+        PostCommitActions asyncPostCommitter = new HBaseAsyncPostCommitter(syncPostCommitter);
+
+        TransactionManager tm = newTransactionManager(context, asyncPostCommitter);
+
+        final CountDownLatch beforeUpdatingShadowCellsLatch = new CountDownLatch(1);
+        final CountDownLatch afterUpdatingShadowCellsLatch = new CountDownLatch(1);
+
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                try {
+                    beforeUpdatingShadowCellsLatch.await();
+                    invocation.callRealMethod();
+                    afterUpdatingShadowCellsLatch.countDown();
+                } catch (Throwable throwable) {
+                    throwable.printStackTrace();
+                }
+                return null;
+            }
+        }).when(syncPostCommitter).updateShadowCells(any(AbstractTransaction.class));
+
+        try (TTable txTable = new TTable(hbaseConf, TEST_TABLE)) {
+
+            // Execute tx with async post commit actions
+            Transaction tx1 = tm.begin();
+
+            Put put1 = new Put(row1);
+            put1.add(family, qualifier, Bytes.toBytes("hey!"));
+            txTable.put(tx1, put1);
+            Put put2 = new Put(row2);
+            put2.add(family, qualifier, Bytes.toBytes("hou!"));
+            txTable.put(tx1, put2);
+
+            tm.commit(tx1);
+
+            long tx1Id = tx1.getTransactionId();
+
+            // As we have paused the update of shadow cells, the shadow cells shouldn't be there yet
+            assertFalse(CellUtils.hasShadowCell(row1, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+            assertFalse(CellUtils.hasShadowCell(row2, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+
+            // Commit Table should contain an entry for the transaction
+            Optional<CommitTable.CommitTimestamp> commitTimestamp = commitTableClient.getCommitTimestamp(tx1Id).get();
+            assertTrue(commitTimestamp.isPresent());
+            assertTrue(commitTimestamp.get().isValid());
+            assertEquals(commitTimestamp.get().getValue(), ((AbstractTransaction) tx1).getCommitTimestamp());
+
+            // Read from row1 and row2 in a different Tx and check that result is the data written by tx1 despite the
+            // post commit actions have not been executed yet (the shadow cells healing process should make its work)
+            Transaction tx2 = tm.begin();
+            Get get1 = new Get(row1);
+            Result result = txTable.get(tx2, get1);
+            byte[] value =  result.getValue(family, qualifier);
+            assertNotNull(value);
+            assertEquals("hey!", Bytes.toString(value));
+
+            Get get2 = new Get(row2);
+            result = txTable.get(tx2, get2);
+            value = result.getValue(family, qualifier);
+            assertNotNull(value);
+            assertEquals("hou!", Bytes.toString(value));
+
+            // Then, we continue with the update of shadow cells and we wait till completed
+            beforeUpdatingShadowCellsLatch.countDown();
+            afterUpdatingShadowCellsLatch.await();
+
+            // Finally, we check that the shadow cells are there
+            assertTrue(CellUtils.hasShadowCell(row1, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+            assertTrue(CellUtils.hasShadowCell(row2, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+
+            verify(syncPostCommitter, times(1)).updateShadowCells(any(AbstractTransaction.class));
+            verify(syncPostCommitter, times(1)).removeCommitTableEntry(any(AbstractTransaction.class));
+
+            // Commit Table should NOT contain the entry for the transaction anymore
+            commitTimestamp = commitTableClient.getCommitTimestamp(tx1Id).get();
+            assertFalse(commitTimestamp.isPresent());
+
+        }
+
+    }
+
+    @Test(timeOut = 30_000)
+    public void testNoAsyncPostActionsAreCalled(ITestContext context) throws Exception {
+
+        CommitTable.Client commitTableClient = getCommitTable(context).getClient();
+
+        PostCommitActions syncPostCommitter =
+                spy(new HBaseSyncPostCommitter(new NullMetricsProvider(), commitTableClient));
+        PostCommitActions asyncPostCommitter = new HBaseAsyncPostCommitter(syncPostCommitter);
+
+        TransactionManager tm = newTransactionManager(context, asyncPostCommitter);
+
+        final CountDownLatch updateShadowCellsCalledLatch = new CountDownLatch(1);
+        final CountDownLatch removeCommitTableEntryCalledLatch = new CountDownLatch(1);
+
+        // Simulate shadow cells are not updated and commit table is not clean
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                // Do not invoke real method simulating a fail of the shadow cells update
+                updateShadowCellsCalledLatch.countDown();
+                return null;
+            }
+        }).when(syncPostCommitter).updateShadowCells(any(AbstractTransaction.class));
+
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                // Do not invoke real method simulating a fail of the async clean of commit table entry
+                removeCommitTableEntryCalledLatch.countDown();
+                return null;
+            }
+        }).when(syncPostCommitter).removeCommitTableEntry(any(AbstractTransaction.class));
+
+
+        try (TTable txTable = new TTable(hbaseConf, TEST_TABLE)) {
+
+            // Execute tx with async post commit actions
+            Transaction tx1 = tm.begin();
+
+            Put put1 = new Put(row1);
+            put1.add(family, qualifier, Bytes.toBytes("hey!"));
+            txTable.put(tx1, put1);
+            Put put2 = new Put(row2);
+            put2.add(family, qualifier, Bytes.toBytes("hou!"));
+            txTable.put(tx1, put2);
+
+            tm.commit(tx1);
+
+            long tx1Id = tx1.getTransactionId();
+
+            // As we have paused the update of shadow cells, the shadow cells shouldn't be there yet
+            assertFalse(CellUtils.hasShadowCell(row1, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+            assertFalse(CellUtils.hasShadowCell(row2, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+
+            // We continue with when both methods have been completed without doing nothing
+            updateShadowCellsCalledLatch.await();
+            removeCommitTableEntryCalledLatch.await();
+
+            // Finally, we check that the shadow cells are NOT there...
+            assertFalse(CellUtils.hasShadowCell(row1, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+            assertFalse(CellUtils.hasShadowCell(row2, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+
+            // ... and the commit table entry has NOT been cleaned
+            Optional<CommitTable.CommitTimestamp> commitTimestamp = commitTableClient.getCommitTimestamp(tx1Id).get();
+            assertTrue(commitTimestamp.isPresent());
+            assertTrue(commitTimestamp.get().isValid());
+        }
+
+    }
+
+    @Test(timeOut = 30_000)
+    public void testOnlyShadowCellsUpdateIsExecuted(ITestContext context) throws Exception {
+
+        CommitTable.Client commitTableClient = getCommitTable(context).getClient();
+
+        PostCommitActions syncPostCommitter =
+                spy(new HBaseSyncPostCommitter(new NullMetricsProvider(), commitTableClient));
+        PostCommitActions asyncPostCommitter = new HBaseAsyncPostCommitter(syncPostCommitter);
+
+        TransactionManager tm = newTransactionManager(context, asyncPostCommitter);
+
+        final CountDownLatch removeCommitTableEntryCalledLatch = new CountDownLatch(1);
+
+        doAnswer(new Answer<Void>() {
+            public Void answer(InvocationOnMock invocation) {
+                // Do not invoke real method simulating a fail of the async clean of commit table entry
+                removeCommitTableEntryCalledLatch.countDown();
+                return null;
+            }
+        }).when(syncPostCommitter).removeCommitTableEntry(any(AbstractTransaction.class));
+
+
+        try (TTable txTable = new TTable(hbaseConf, TEST_TABLE)) {
+
+            // Execute tx with async post commit actions
+            Transaction tx1 = tm.begin();
+
+            Put put1 = new Put(row1);
+            put1.add(family, qualifier, Bytes.toBytes("hey!"));
+            txTable.put(tx1, put1);
+            Put put2 = new Put(row2);
+            put2.add(family, qualifier, Bytes.toBytes("hou!"));
+            txTable.put(tx1, put2);
+
+            tm.commit(tx1);
+
+            long tx1Id = tx1.getTransactionId();
+
+            // As we have paused the update of shadow cells, the shadow cells shouldn't be there yet
+            assertFalse(CellUtils.hasShadowCell(row1, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+            assertFalse(CellUtils.hasShadowCell(row2, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+
+            // We continue with when the unsuccessful call of the method for cleaning commit table has been invoked
+            removeCommitTableEntryCalledLatch.await();
+
+            // Finally, we check that the shadow cells are there...
+            assertTrue(CellUtils.hasShadowCell(row1, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+            assertTrue(CellUtils.hasShadowCell(row2, family, qualifier, tx1Id, new TTableCellGetterAdapter(txTable)));
+
+            // ... and the commit table entry has NOT been cleaned
+            Optional<CommitTable.CommitTimestamp> commitTimestamp = commitTableClient.getCommitTimestamp(tx1Id).get();
+            assertTrue(commitTimestamp.isPresent());
+            assertTrue(commitTimestamp.get().isValid());
+        }
+
+    }
+
+}

--- a/transaction-client/src/main/java/com/yahoo/omid/transaction/PostCommitActions.java
+++ b/transaction-client/src/main/java/com/yahoo/omid/transaction/PostCommitActions.java
@@ -15,6 +15,7 @@
  */
 package com.yahoo.omid.transaction;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.omid.tsoclient.CellId;
 
 public interface PostCommitActions {
@@ -23,26 +24,16 @@ public interface PostCommitActions {
      * Allows specific implementations to update the shadow cells.
      * @param transaction
      *            the transaction to update shadow cells for
-     * @throws TransactionManagerException
+     * @return future signalling end of the computation
      */
-    void updateShadowCells(AbstractTransaction<? extends CellId> transaction) throws TransactionManagerException;
+    ListenableFuture<Void> updateShadowCells(AbstractTransaction<? extends CellId> transaction);
 
     /**
      * Allows specific implementations to remove the transaction entry from the commit table.
      * @param transaction
      *            the transaction to remove the commit table entry
-     * @throws TransactionManagerException
+     * @return future signalling end of the computation
      */
-    void removeCommitTableEntry(AbstractTransaction<? extends CellId> transaction) throws TransactionManagerException;
-
-    /**
-     * Allows specific implementations to update the shadow cells and remove the transaction entry from the commit
-     * table sequentially.
-     * @param transaction
-     *            the transaction to update the shadow cells and remove the commit table entry
-     * @throws TransactionManagerException
-     */
-    void updateShadowCellsAndRemoveCommitTableEntry(AbstractTransaction<? extends CellId> transaction)
-            throws TransactionManagerException;
+    ListenableFuture<Void> removeCommitTableEntry(AbstractTransaction<? extends CellId> transaction);
 
 }

--- a/transaction-client/src/main/java/com/yahoo/omid/transaction/PostCommitActions.java
+++ b/transaction-client/src/main/java/com/yahoo/omid/transaction/PostCommitActions.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2011-2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.omid.transaction;
+
+import com.yahoo.omid.tsoclient.CellId;
+
+public interface PostCommitActions {
+
+    /**
+     * Allows specific implementations to update the shadow cells.
+     * @param transaction
+     *            the transaction to update shadow cells for
+     * @throws TransactionManagerException
+     */
+    void updateShadowCells(AbstractTransaction<? extends CellId> transaction) throws TransactionManagerException;
+
+    /**
+     * Allows specific implementations to remove the transaction entry from the commit table.
+     * @param transaction
+     *            the transaction to remove the commit table entry
+     * @throws TransactionManagerException
+     */
+    void removeCommitTableEntry(AbstractTransaction<? extends CellId> transaction) throws TransactionManagerException;
+
+    /**
+     * Allows specific implementations to update the shadow cells and remove the transaction entry from the commit
+     * table sequentially.
+     * @param transaction
+     *            the transaction to update the shadow cells and remove the commit table entry
+     * @throws TransactionManagerException
+     */
+    void updateShadowCellsAndRemoveCommitTableEntry(AbstractTransaction<? extends CellId> transaction)
+            throws TransactionManagerException;
+
+}


### PR DESCRIPTION
HBaseTransactionManager has been modified to allow users select
sync or async shadow cells updates when creating the transaction
manager instance.

With async shadow cell updates, the control is returned to
the client earlier. It is also ensured that the transaction will be
removed from the commit table only after the shadow cells of the
transaction committed have been updated.

Change-Id: I0a75246d4be5b248096268ff8db904a3f499aef9