### PR TITLE
Avoid storing LOW WATERMARK everytime a transaction is validated

### DIFF
--- a/tso-server/src/main/java/com/yahoo/omid/tso/RequestProcessorImpl.java
+++ b/tso-server/src/main/java/com/yahoo/omid/tso/RequestProcessorImpl.java
@@ -93,7 +93,7 @@ public class RequestProcessorImpl implements EventHandler<RequestProcessorImpl.R
         persistProc.persistLowWatermark(lowWatermark);
         this.epoch = state.getEpoch();
         hashmap.reset();
-        LOG.info("RequestProcessor initialized with LWM {} and Epoch {}", lowWatermark, epoch);
+        LOG.info("RequestProcessor initialized with LWMs {} and Epoch {}", lowWatermark, epoch);
     }
 
     @Override
@@ -185,9 +185,11 @@ public class RequestProcessorImpl implements EventHandler<RequestProcessorImpl.R
                         newLowWatermark = Math.max(removed, newLowWatermark);
                     }
 
-                    lowWatermark = newLowWatermark;
-                    LOG.trace("Setting new low Watermark to {}", newLowWatermark);
-                    persistProc.persistLowWatermark(newLowWatermark);
+                    if (newLowWatermark != lowWatermark) {
+                        LOG.trace("Setting new low Watermark to {}", newLowWatermark);
+                        lowWatermark = newLowWatermark;
+                        persistProc.persistLowWatermark(newLowWatermark);
+                    }
                 }
                 persistProc.persistCommit(startTimestamp, commitTimestamp, c, event.getMonCtx());
             } catch (IOException e) {

--- a/tso-server/src/test/java/com/yahoo/omid/tso/TestRequestProcessor.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tso/TestRequestProcessor.java
@@ -25,6 +25,10 @@ import static org.testng.AssertJUnit.assertTrue;
 public class TestRequestProcessor {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestRequestProcessor.class);
+
+    private static final int CONFLICT_MAP_SIZE = 1000;
+    private static final int CONFLICT_MAP_ASSOCIATIVITY = 32;
+
     private MetricsRegistry metrics = new NullMetricsProvider();
 
     private PersistenceProcessor persist;
@@ -47,7 +51,7 @@ public class TestRequestProcessor {
 
         persist = mock(PersistenceProcessor.class);
 
-        String[] configArgs = new String[]{"-maxItems", "1000"};
+        String[] configArgs = new String[]{"-maxItems", Integer.toString(CONFLICT_MAP_SIZE)};
         TSOServerCommandLineConfig config = TSOServerCommandLineConfig.parseConfig(configArgs);
 
         requestProc = new RequestProcessorImpl(metrics,
@@ -134,6 +138,31 @@ public class TestRequestProcessor {
         // ...check that the transaction is aborted when trying to commit
         requestProc.commitRequest(startTS, writeSet, false, null, new MonitoringContext(metrics));
         verify(persist, timeout(100).times(1)).persistAbort(eq(startTS), anyBoolean(), any(Channel.class), any(MonitoringContext.class));
+
+    }
+
+    @Test(timeOut = 5_000)
+    public void testLowWatermarkIsStoredOnlyWhenACacheElementIsEvicted() throws Exception {
+
+        final int ANY_START_TS = 1;
+        final long FIRST_COMMIT_TS_EVICTED = 1L;
+        final long NEXT_COMMIT_TS_THAT_SHOULD_BE_EVICTED = 2L;
+
+        // Fill the cache to provoke a cache eviction
+        for (long i = 0; i < CONFLICT_MAP_SIZE + CONFLICT_MAP_ASSOCIATIVITY; i++) {
+            long writeSetElementHash = i + 1; // This is to match the assigned CT: K/V in cache = WS Element Hash/CT
+            List<Long> writeSet = Lists.newArrayList(writeSetElementHash);
+            requestProc.commitRequest(ANY_START_TS, writeSet, false, null, new MonitoringContext(metrics));
+        }
+
+        Thread.currentThread().sleep(3000); // Allow the Request processor to finish the request processing
+
+        // Check that first time its called is on init
+        verify(persist, timeout(100).times(1)).persistLowWatermark(0L);
+        // Then, check it is called when cache is full and the first element is evicted (should be a 1)
+        verify(persist, timeout(100).times(1)).persistLowWatermark(FIRST_COMMIT_TS_EVICTED);
+        // Finally it should never be called with the next element
+        verify(persist, timeout(100).never()).persistLowWatermark(NEXT_COMMIT_TS_THAT_SHOULD_BE_EVICTED);
 
     }
 

--- a/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestTSOClientConnectionToTSO.java
+++ b/tso-server/src/test/java/com/yahoo/omid/tsoclient/TestTSOClientConnectionToTSO.java
@@ -207,6 +207,7 @@ public class TestTSOClientConnectionToTSO {
         TestUtils.waitForSocketNotListening(TSO_HOST, tsoPortForTest, 1000);
         LOG.info("Initial TSO Server Stopped");
 
+        Thread.sleep(1500); // ...allow the client to receive disconnection event...
         // ... and check that we get a conn exception when trying to access the client
         try {
             startTS = tsoClient.getNewStartTimestamp().get();


### PR DESCRIPTION
Also, in HBaseCommitTable, append low watermark directly to
a value and add it as a Put only at flush time. Finally, the
PersistentProcessorImpl avoids to create a Disruptor event to
these kind of updates.

Change-Id: I99fc30b3787927488854e36526a60e924ac404d1