### PR TITLE
Reduce default settings in omid config, so that out-of-the-box TSO server performs faster on low traffic use-cases

### DIFF
--- a/tso-server/src/main/resources/default-omid.yml
+++ b/tso-server/src/main/resources/default-omid.yml
@@ -15,8 +15,8 @@
 # Port reserved by the Status Oracle
 port: 54758
 maxItems: 100000000
-maxBatchSize: 10000
-batchPersistTimeoutMS: 100
+maxBatchSize: 25
+batchPersistTimeoutMS: 10
 
 # Default module configuration (No TSO High Availability & in-memory storage for timestamp and commit tables)
 timestampStoreModule: !!com.yahoo.omid.tso.InMemoryTimestampStorageModule [ ]


### PR DESCRIPTION
Reduce default settings in omid config, so that out-of-the-box TSO server performs faster on low traffic use-cases

Change-Id: I7dab6cfeb0d13636185f0bda256a2e9f7696a98a