### PR TITLE
Remove IOException from TimestampOracle intf

### DIFF
--- a/tso-server/src/main/java/org/apache/omid/tso/TimestampOracle.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/TimestampOracle.java
@@ -19,16 +19,26 @@ package org.apache.omid.tso;
 
 import java.io.IOException;
 
+/**
+ * Functionality of a service delivering monotonic increasing timestamps.
+ */
 public interface TimestampOracle {
 
+    /**
+     * Allows the initialization of the Timestamp Oracle service.
+     * @throws IOException
+     *          raised if a problem during initialization is shown.
+     */
     void initialize() throws IOException;
 
     /**
-     * Returns the next timestamp if available. Otherwise spins till the
-     * ts-persist thread performs the new timestamp allocation
+     * Returns the next timestamp.
      */
-    long next() throws IOException;
+    long next();
 
+    /**
+     * Returns the last timestamp assigned.
+     */
     long getLast();
 
 }

--- a/tso-server/src/main/java/org/apache/omid/tso/TimestampOracleImpl.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/TimestampOracleImpl.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Executors;
 import static org.apache.omid.metrics.MetricsUtils.name;
 
 /**
- * The Timestamp Oracle that gives monotonically increasing timestamps
+ * The Timestamp Oracle that gives monotonically increasing timestamps.
  */
 @Singleton
 public class TimestampOracleImpl implements TimestampOracle {
@@ -129,12 +129,11 @@ public class TimestampOracleImpl implements TimestampOracle {
     }
 
     /**
-     * Returns the next timestamp if available. Otherwise spins till the
-     * ts-persist thread performs the new timestamp allocation
+     * Returns the next timestamp if available. Otherwise spins till the ts-persist thread allocates a new timestamp.
      */
     @SuppressWarnings("StatementWithEmptyBody")
     @Override
-    public long next() throws IOException {
+    public long next() {
         lastTimestamp++;
 
         if (lastTimestamp == nextAllocationThreshold) {

--- a/tso-server/src/test/java/org/apache/omid/tso/PausableTimestampOracle.java
+++ b/tso-server/src/test/java/org/apache/omid/tso/PausableTimestampOracle.java
@@ -39,7 +39,7 @@ public class PausableTimestampOracle extends TimestampOracleImpl {
     }
 
     @Override
-    public long next() throws IOException {
+    public long next() {
         while (tsoPaused) {
             synchronized (this) {
                 try {

--- a/tso-server/src/test/java/org/apache/omid/tso/TestPanicker.java
+++ b/tso-server/src/test/java/org/apache/omid/tso/TestPanicker.java
@@ -77,12 +77,8 @@ public class TestPanicker {
         Thread allocThread = new Thread("AllocThread") {
             @Override
             public void run() {
-                try {
-                    while (true) {
-                        tso.next();
-                    }
-                } catch (IOException ioe) {
-                    LOG.error("Shouldn't occur");
+                while (true) {
+                    tso.next();
                 }
             }
         };

--- a/tso-server/src/test/java/org/apache/omid/tso/TestTimestampOracle.java
+++ b/tso-server/src/test/java/org/apache/omid/tso/TestTimestampOracle.java
@@ -97,12 +97,8 @@ public class TestTimestampOracle {
         Thread allocThread = new Thread("AllocThread") {
             @Override
             public void run() {
-                try {
-                    while (true) {
-                        timestampOracle.next();
-                    }
-                } catch (IOException ioe) {
-                    LOG.error("Shouldn't occur");
+                while (true) {
+                    timestampOracle.next();
                 }
             }
         };


### PR DESCRIPTION
The unnecessary exception introduced a several unnecessary boilerplate code in several classes.
Also the TimestampOracle interface has been commented properly.

Change-Id: I510e7677f07299061aebfd23f7a8d189e177a4f1