### PR TITLE
[OMID-36] Use SystemExitPanicker for killing TSO process

### DIFF
--- a/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessor.java
@@ -19,9 +19,10 @@ package org.apache.omid.tso;
 
 import org.jboss.netty.channel.Channel;
 
+import java.io.Closeable;
 import java.util.concurrent.Future;
 
-interface PersistenceProcessor {
+interface PersistenceProcessor extends Closeable {
 
     void addCommitToBatch(long startTimestamp, long commitTimestamp, Channel c, MonitoringContext monCtx)
             throws Exception;

--- a/tso-server/src/main/java/org/apache/omid/tso/ReplyProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/ReplyProcessor.java
@@ -19,7 +19,9 @@ package org.apache.omid.tso;
 
 import org.jboss.netty.channel.Channel;
 
-interface ReplyProcessor {
+import java.io.Closeable;
+
+interface ReplyProcessor extends Closeable {
 
     /**
      * The each reply to a transactional operation for a client is contained in a batch. The batch must be ordered

--- a/tso-server/src/main/java/org/apache/omid/tso/RetryProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/RetryProcessor.java
@@ -19,6 +19,8 @@ package org.apache.omid.tso;
 
 import org.jboss.netty.channel.Channel;
 
-interface RetryProcessor {
+import java.io.Closeable;
+
+interface RetryProcessor extends Closeable {
     void disambiguateRetryRequestHeuristically(long startTimestamp, Channel c, MonitoringContext monCtx);
 }

--- a/tso-server/src/main/java/org/apache/omid/tso/SystemExitPanicker.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/SystemExitPanicker.java
@@ -17,16 +17,22 @@
  */
 package org.apache.omid.tso;
 
-import org.jboss.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
-import java.util.Collection;
+public class SystemExitPanicker implements Panicker {
 
-// NOTE: public is required explicitly in the interface definition for Guice injection
-public interface RequestProcessor extends TSOStateManager.StateObserver, Closeable {
+    private static final Logger LOG = LoggerFactory.getLogger(SystemExitPanicker.class);
 
-    void timestampRequest(Channel c, MonitoringContext monCtx);
+    @Override
+    public void panic(String reason) {
+        panic(reason, new Throwable("TSO Error"));
+    }
 
-    void commitRequest(long startTimestamp, Collection<Long> writeSet, boolean isRetry, Channel c, MonitoringContext monCtx);
+    @Override
+    public void panic(String reason, Throwable cause) {
+        LOG.error(reason, cause);
+        System.exit(-1);
+    }
 
 }

--- a/tso-server/src/main/java/org/apache/omid/tso/TSOModule.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/TSOModule.java
@@ -44,7 +44,7 @@ class TSOModule extends AbstractModule {
         bind(TSOChannelHandler.class).in(Singleton.class);
         bind(TSOStateManager.class).to(TSOStateManagerImpl.class).in(Singleton.class);
         bind(TimestampOracle.class).to(TimestampOracleImpl.class).in(Singleton.class);
-        bind(Panicker.class).to(RuntimeExceptionPanicker.class).in(Singleton.class);
+        bind(Panicker.class).to(SystemExitPanicker.class).in(Singleton.class);
 
         install(new BatchPoolModule(config));
         // Disruptor setup


### PR DESCRIPTION
Exit the JVM when an exception occurs in the TSO processors instead
of throwing a RuntimeException. With the Runtime exception, the process
hangs without exiting, which avoids the process to be relaunched in
both HA and non-HA scenarios.

Also terminate (close) all the TSO processor in an orderly manner when
shutdown.

Finally, log info has been added for both the startup and the shutdown
phases.

Change-Id: I0800f4fae98de29cbf02502db42700b0a1cdb280