### PR TITLE
[OMID-72] Add fences to support secondary index in Phoenix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - git config --global user.name "Omid CI"
   # Install protobuf to genearte TSO client-server protocol in each compilation
   - cd ..
-  - wget https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz
+  - wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
   - tar -xzvf protobuf-2.5.0.tar.gz
   - cd protobuf-2.5.0 && ./configure --prefix=/usr && make && sudo make install
   - cd ../incubator-omid

--- a/common/src/main/proto/TSOProto.proto
+++ b/common/src/main/proto/TSOProto.proto
@@ -64,3 +64,4 @@ message HandshakeResponse {
     optional bool clientCompatible = 1;
     optional Capabilities serverCapabilities = 2;
 }
+

--- a/common/src/main/proto/TSOProto.proto
+++ b/common/src/main/proto/TSOProto.proto
@@ -24,6 +24,7 @@ message Request {
     optional TimestampRequest timestampRequest = 1;
     optional CommitRequest commitRequest = 2;
     optional HandshakeRequest handshakeRequest = 3;
+    optional FenceRequest fenceRequest = 4;
 }
 
 message TimestampRequest {
@@ -33,16 +34,27 @@ message CommitRequest {
     optional int64 startTimestamp = 1;
     optional bool isRetry = 2 [default = false];
     repeated int64 cellId = 3;
+    repeated int64 TableId = 4;
+}
+
+message FenceRequest {
+    optional int64 TableId = 1;
 }
 
 message Response {
     optional TimestampResponse timestampResponse = 1;
     optional CommitResponse commitResponse = 2;
     optional HandshakeResponse handshakeResponse = 3;
+    optional FenceResponse fenceResponse = 4;
 }
 
 message TimestampResponse {
     optional int64 startTimestamp = 1;
+}
+
+message FenceResponse {
+    optional int64 TableId = 1;
+    optional int64 FenceId = 2;
 }
 
 message CommitResponse {

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseCellId.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseCellId.java
@@ -17,7 +17,9 @@
  */
 package org.apache.omid.transaction;
 
+import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+
 import org.apache.omid.tso.client.CellId;
 import org.apache.hadoop.hbase.client.HTableInterface;
 
@@ -67,9 +69,13 @@ public class HBaseCellId implements CellId {
                 + ":" + timestamp;
     }
 
+    private Hasher getHasher() {
+        return Hashing.murmur3_128().newHasher();
+    }
+
     @Override
     public long getCellId() {
-        return Hashing.murmur3_128().newHasher()
+        return getHasher()
                 .putBytes(table.getTableName())
                 .putBytes(row)
                 .putBytes(family)
@@ -77,4 +83,11 @@ public class HBaseCellId implements CellId {
                 .hash().asLong();
     }
 
+    @Override
+    public long getRowId() {
+        return getHasher()
+                .putBytes(table.getTableName())
+                .putBytes(row)
+                .hash().asLong();
+    }
 }

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseCellId.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseCellId.java
@@ -77,4 +77,10 @@ public class HBaseCellId implements CellId {
                 .hash().asLong();
     }
 
+    @Override
+    public long getTableId() {
+        return Hashing.murmur3_128().newHasher()
+                .putBytes(table.getTableName())
+                .hash().asLong();
+    }
 }

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseCellId.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseCellId.java
@@ -17,7 +17,9 @@
  */
 package org.apache.omid.transaction;
 
+import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+
 import org.apache.omid.tso.client.CellId;
 import org.apache.hadoop.hbase.client.HTableInterface;
 
@@ -69,7 +71,7 @@ public class HBaseCellId implements CellId {
 
     @Override
     public long getCellId() {
-        return Hashing.murmur3_128().newHasher()
+        return getHasher()
                 .putBytes(table.getTableName())
                 .putBytes(row)
                 .putBytes(family)
@@ -79,8 +81,12 @@ public class HBaseCellId implements CellId {
 
     @Override
     public long getTableId() {
-        return Hashing.murmur3_128().newHasher()
+        return getHasher()
                 .putBytes(table.getTableName())
                 .hash().asLong();
+    }
+
+    public static Hasher getHasher() {
+        return Hashing.murmur3_128().newHasher();
     }
 }

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseOmidClientConfiguration.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseOmidClientConfiguration.java
@@ -20,9 +20,11 @@ package org.apache.omid.transaction;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+
 import org.apache.omid.YAMLUtils;
 import org.apache.omid.metrics.MetricsRegistry;
 import org.apache.omid.tools.hbase.SecureHBaseConfig;
+import org.apache.omid.tso.client.OmidClientConfiguration.ConflictDetectionLevel;
 import org.apache.omid.tso.client.OmidClientConfiguration.PostCommitMode;
 import org.apache.omid.tso.client.OmidClientConfiguration;
 import org.apache.hadoop.conf.Configuration;
@@ -71,6 +73,14 @@ public class HBaseOmidClientConfiguration extends SecureHBaseConfig {
 
     public void setPostCommitMode(PostCommitMode postCommitMode) {
         omidClientConfiguration.setPostCommitMode(postCommitMode);
+    }
+
+    public ConflictDetectionLevel getConflictAnalysisLevel() {
+        return omidClientConfiguration.getConflictAnalysisLevel();
+    }
+
+    public void setConflictAnalysisLevel(ConflictDetectionLevel conflictAnalysisLevel) {
+        omidClientConfiguration.setConflictAnalysisLevel(conflictAnalysisLevel);
     }
 
     public String getCommitTableName() {

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class HBaseTransaction extends AbstractTransaction<HBaseCellId> {

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransaction.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public class HBaseTransaction extends AbstractTransaction<HBaseCellId> {
     private static final Logger LOG = LoggerFactory.getLogger(HBaseTransaction.class);
 
-    HBaseTransaction(long transactionId, long epoch, Set<HBaseCellId> writeSet, AbstractTransactionManager tm) {
+    public HBaseTransaction(long transactionId, long epoch, Set<HBaseCellId> writeSet, AbstractTransactionManager tm) {
         super(transactionId, epoch, writeSet, tm);
     }
 

--- a/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
+++ b/hbase-client/src/main/java/org/apache/omid/transaction/HBaseTransactionManager.java
@@ -20,9 +20,11 @@ package org.apache.omid.transaction;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.apache.omid.committable.CommitTable;
 import org.apache.omid.committable.CommitTable.CommitTimestamp;
 import org.apache.omid.committable.hbase.HBaseCommitTable;
@@ -193,6 +195,11 @@ public class HBaseTransactionManager extends AbstractTransactionManager implemen
         } catch (IOException e) {
             throw new TransactionManagerException("Exception while flushing writes", e);
         }
+    }
+
+    @Override
+    public long getHashForTable(byte[] tableName) {
+        return HBaseCellId.getHasher().putBytes(tableName).hash().asLong();
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/transaction-client/src/main/java/org/apache/omid/transaction/AbstractTransactionManager.java
+++ b/transaction-client/src/main/java/org/apache/omid/transaction/AbstractTransactionManager.java
@@ -163,10 +163,20 @@ public abstract class AbstractTransactionManager implements TransactionManager {
         }
     }
 
+    /**
+     * Generates hash ID for table name, this hash is later-on sent to the TSO and used for fencing
+     * @param tableName - the table name
+     * @return
+     */
+    abstract public long getHashForTable(byte[] tableName);
+
+    /**
+     * @see org.apache.omid.transaction.TransactionManager#fence()
+     */
     @Override
     public final Transaction fence(byte[] tableName) throws TransactionException {
         long fenceTimestamp;
-        long tableID = Hashing.murmur3_128().newHasher().putBytes(tableName).hash().asLong();
+        long tableID = getHashForTable(tableName); Hashing.murmur3_128().newHasher().putBytes(tableName).hash().asLong();
 
         try {
             fenceTimer.start();

--- a/transaction-client/src/main/java/org/apache/omid/transaction/AbstractTransactionManager.java
+++ b/transaction-client/src/main/java/org/apache/omid/transaction/AbstractTransactionManager.java
@@ -19,7 +19,9 @@ package org.apache.omid.transaction;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.Futures;
+
 import org.apache.omid.committable.CommitTable;
 import org.apache.omid.committable.CommitTable.CommitTimestamp;
 import org.apache.omid.metrics.Counter;
@@ -70,6 +72,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     // Metrics
     private final Timer startTimestampTimer;
     private final Timer commitTimer;
+    private final Timer fenceTimer;
     private final Counter committedTxsCounter;
     private final Counter rolledbackTxsCounter;
     private final Counter errorTxsCounter;
@@ -104,6 +107,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
         // Metrics configuration
         this.startTimestampTimer = metrics.timer(name("omid", "tm", "hbase", "startTimestamp", "latency"));
         this.commitTimer = metrics.timer(name("omid", "tm", "hbase", "commit", "latency"));
+        this.fenceTimer = metrics.timer(name("omid", "tm", "hbase", "fence", "latency"));
         this.committedTxsCounter = metrics.counter(name("omid", "tm", "hbase", "committedTxs"));
         this.rolledbackTxsCounter = metrics.counter(name("omid", "tm", "hbase", "rolledbackTxs"));
         this.errorTxsCounter = metrics.counter(name("omid", "tm", "hbase", "erroredTxs"));
@@ -156,6 +160,30 @@ public abstract class AbstractTransactionManager implements TransactionManager {
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new TransactionException("Interrupted getting timestamp", ie);
+        }
+    }
+
+    @Override
+    public final Transaction fence(byte[] tableName) throws TransactionException {
+        long fenceTimestamp;
+        long tableID = Hashing.murmur3_128().newHasher().putBytes(tableName).hash().asLong();
+
+        try {
+            fenceTimer.start();
+            try {
+                fenceTimestamp = tsoClient.getFence(tableID).get();
+            } finally {
+                fenceTimer.stop();
+            }
+
+            AbstractTransaction<? extends CellId> tx = transactionFactory.createTransaction(fenceTimestamp, fenceTimestamp, this);
+
+            return tx;
+        } catch (ExecutionException e) {
+            throw new TransactionException("Could not get fence", e);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new TransactionException("Interrupted creating a fence", ie);
         }
     }
 

--- a/transaction-client/src/main/java/org/apache/omid/transaction/TransactionManager.java
+++ b/transaction-client/src/main/java/org/apache/omid/transaction/TransactionManager.java
@@ -61,10 +61,10 @@ public interface TransactionManager extends Closeable {
     /**
     * Creates a fence
     *
-    * Creates a fence and returns a {@link Transaction} interface implementation that contains the fence timestamp
+    * Creates a fence and returns a {@link Transaction} interface implementation that contains the fence information.
     *
     * @param tableName name of the table that requires a fence
-    * @return transaction representation contains the fence timestamp
+    * @return transaction representation contains the fence timestamp as the TransactionId.
     * @throws TransactionException in case of any issues
     */
     Transaction fence(byte[] tableName) throws TransactionException;

--- a/transaction-client/src/main/java/org/apache/omid/transaction/TransactionManager.java
+++ b/transaction-client/src/main/java/org/apache/omid/transaction/TransactionManager.java
@@ -58,4 +58,15 @@ public interface TransactionManager extends Closeable {
      */
     void rollback(Transaction tx) throws TransactionException;
 
+    /**
+    * Creates a fence
+    *
+    * Creates a fence and returns a {@link Transaction} interface implementation that contains the fence timestamp
+    *
+    * @param tableName name of the table that requires a fence
+    * @return transaction representation contains the fence timestamp
+    * @throws TransactionException in case of any issues
+    */
+    Transaction fence(byte[] tableName) throws TransactionException;
+
 }

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/CellId.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/CellId.java
@@ -20,5 +20,6 @@ package org.apache.omid.tso.client;
 public interface CellId {
 
     long getCellId();
+    long getRowId();
 
 }

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/CellId.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/CellId.java
@@ -20,5 +20,6 @@ package org.apache.omid.tso.client;
 public interface CellId {
 
     long getCellId();
+    long getTableId();
 
 }

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/OmidClientConfiguration.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/OmidClientConfiguration.java
@@ -32,6 +32,8 @@ public class OmidClientConfiguration {
 
     public enum PostCommitMode {SYNC, ASYNC}
 
+    public enum ConflictDetectionLevel {CELL, ROW}
+
     // Basic connection related params
 
     private ConnType connectionType = ConnType.DIRECT;
@@ -51,6 +53,7 @@ public class OmidClientConfiguration {
     // Transaction Manager related params
 
     private PostCommitMode postCommitMode = PostCommitMode.SYNC;
+    private ConflictDetectionLevel conflictAnalysisLevel = ConflictDetectionLevel.CELL;
 
     // ----------------------------------------------------------------------------------------------------------------
     // Instantiation
@@ -174,4 +177,13 @@ public class OmidClientConfiguration {
         this.postCommitMode = postCommitMode;
     }
 
+    public ConflictDetectionLevel getConflictAnalysisLevel() {
+        return conflictAnalysisLevel;
+    }
+
+    @Inject(optional = true)
+    @Named("omid.tm.conflictAnalysisLevel")
+    public void setConflictAnalysisLevel(ConflictDetectionLevel conflictAnalysisLevel) {
+        this.conflictAnalysisLevel = conflictAnalysisLevel;
+    }
 }

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOClient.java
@@ -95,6 +95,7 @@ public class TSOClient implements TSOProtocol, NodeCacheListener {
     private InetSocketAddress tsoAddr;
     private String zkCurrentTsoPath;
 
+    // Use to extract unique table identifiers from the modified cells list.
     private final Set<Long> tableIDs;
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOProtocol.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOProtocol.java
@@ -19,6 +19,8 @@ package org.apache.omid.tso.client;
 
 import java.util.Set;
 
+import org.apache.omid.tso.client.OmidClientConfiguration.ConflictDetectionLevel;
+
 /**
  * Defines the protocol used on the client side to abstract communication to the TSO server
  */

--- a/transaction-client/src/main/java/org/apache/omid/tso/client/TSOProtocol.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/client/TSOProtocol.java
@@ -17,6 +17,7 @@
  */
 package org.apache.omid.tso.client;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -46,6 +47,17 @@ public interface TSOProtocol {
      * see org.apache.omid.tso.TSOServer
      */
     TSOFuture<Long> commit(long transactionId, Set<? extends CellId> writeSet);
+
+    /**
+     * Returns a new fence timestamp assigned by on the server-side
+     * @param tableId
+     *          the table to create fence for.
+     * @return the newly assigned timestamp as a future. If an error was detected, the future will contain a
+     * corresponding protocol exception
+     * see org.apache.omid.tso.TimestampOracle
+     * see org.apache.omid.tso.TSOServer
+     */
+    TSOFuture<Long> getFence(long tableId);
 
     /**
      * Closes the communication with the TSO server

--- a/transaction-client/src/main/java/org/apache/omid/tso/util/DummyCellIdImpl.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/util/DummyCellIdImpl.java
@@ -22,9 +22,15 @@ import org.apache.omid.tso.client.CellId;
 public class DummyCellIdImpl implements CellId {
 
     private final long cellId;
+    private final long rowId;
 
     public DummyCellIdImpl(long cellId) {
+        this(cellId, cellId);
+    }
+
+    public DummyCellIdImpl(long cellId, long rowId) {
         this.cellId = cellId;
+        this.rowId = rowId;
     }
 
     @Override
@@ -32,4 +38,8 @@ public class DummyCellIdImpl implements CellId {
         return cellId;
     }
 
+    @Override
+    public long getRowId() {
+        return rowId;
+    }
 }

--- a/transaction-client/src/main/java/org/apache/omid/tso/util/DummyCellIdImpl.java
+++ b/transaction-client/src/main/java/org/apache/omid/tso/util/DummyCellIdImpl.java
@@ -32,4 +32,8 @@ public class DummyCellIdImpl implements CellId {
         return cellId;
     }
 
+    @Override
+    public long getTableId() {
+        return cellId;
+    }
 }

--- a/transaction-client/src/main/resources/omid-client-config.yml
+++ b/transaction-client/src/main/resources/omid-client-config.yml
@@ -37,3 +37,7 @@ executorThreads: 3
 # Configure whether the TM performs the post-commit actions for a tx (update shadow cells and clean commit table entry)
 # before returning to the control to the client (SYNC) or in parallel (ASYNC)
 postCommitMode: !!org.apache.omid.tso.client.OmidClientConfiguration$PostCommitMode SYNC
+
+# Conflict analysis level
+# Can either be cell level or row level. Default is cell level
+conflictDetectionLevel: !!org.apache.omid.tso.client.OmidClientConfiguration$ConflictDetectionLevel CELL

--- a/tso-server/src/main/java/org/apache/omid/tso/Batch.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/Batch.java
@@ -103,6 +103,16 @@ public class Batch {
 
     }
 
+    void addFence(long tableID, long fenceTimestamp, Channel c, MonitoringContext context) {
+
+        Preconditions.checkState(!isFull(), "batch is full");
+        int index = numEvents++;
+        PersistEvent e = events[index];
+        context.timerStart("persistence.processor.fence.latency");
+        e.makePersistFence(tableID, fenceTimestamp, c, context);
+
+    }
+
     void addCommit(long startTimestamp, long commitTimestamp, Channel c, MonitoringContext context) {
 
         Preconditions.checkState(!isFull(), "batch is full");

--- a/tso-server/src/main/java/org/apache/omid/tso/PersistEvent.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/PersistEvent.java
@@ -25,7 +25,7 @@ public final class PersistEvent {
     private MonitoringContext monCtx;
 
     enum Type {
-        TIMESTAMP, COMMIT, ABORT, COMMIT_RETRY
+        TIMESTAMP, COMMIT, ABORT, COMMIT_RETRY, FENCE
     }
 
     private Type type = null;
@@ -66,6 +66,16 @@ public final class PersistEvent {
 
         this.type = Type.TIMESTAMP;
         this.startTimestamp = startTimestamp;
+        this.channel = c;
+        this.monCtx = monCtx;
+
+    }
+
+    void makePersistFence(long tableID, long fenceTimestamp, Channel c, MonitoringContext monCtx) {
+
+        this.type = Type.FENCE;
+        this.startTimestamp = tableID;
+        this.commitTimestamp = fenceTimestamp;
         this.channel = c;
         this.monCtx = monCtx;
 

--- a/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessor.java
@@ -33,6 +33,8 @@ interface PersistenceProcessor extends Closeable {
 
     void addTimestampToBatch(long startTimestamp, Channel c, MonitoringContext monCtx) throws Exception;
 
+    void addFenceToBatch(long tableID, long fenceTimestamp, Channel c, MonitoringContext monCtx) throws Exception;
+
     void triggerCurrentBatchFlush() throws Exception;
 
     Future<Void> persistLowWatermark(long lowWatermark);

--- a/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessorHandler.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessorHandler.java
@@ -96,6 +96,7 @@ public class PersistenceProcessorHandler implements WorkHandler<PersistenceProce
                     event.getMonCtx().timerStop("persistence.processor.abort.latency");
                     break;
                 case FENCE:
+                    // Persist the fence by using the fence identifier as both the start and commit timestamp.
                     writer.addCommittedTransaction(event.getCommitTimestamp(), event.getCommitTimestamp());
                     commitEventsToFlush++;
                     break;

--- a/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessorHandler.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessorHandler.java
@@ -95,6 +95,10 @@ public class PersistenceProcessorHandler implements WorkHandler<PersistenceProce
                 case ABORT:
                     event.getMonCtx().timerStop("persistence.processor.abort.latency");
                     break;
+                case FENCE:
+                    writer.addCommittedTransaction(event.getCommitTimestamp(), event.getCommitTimestamp());
+                    commitEventsToFlush++;
+                    break;
                 default:
                     throw new IllegalStateException("Event not allowed in Persistent Processor Handler: " + event);
             }
@@ -118,6 +122,10 @@ public class PersistenceProcessorHandler implements WorkHandler<PersistenceProce
                     throw new IllegalStateException("COMMIT_RETRY events must be filtered before this step: " + event);
                 case ABORT:
                     event.getMonCtx().timerStart("reply.processor.abort.latency");
+                    break;
+                case FENCE:
+                    event.getMonCtx().timerStop("persistence.processor.fence.latency");
+                    event.getMonCtx().timerStart("reply.processor.fence.latency");
                     break;
                 default:
                     throw new IllegalStateException("Event not allowed in Persistent Processor Handler: " + event);

--- a/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessorImpl.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/PersistenceProcessorImpl.java
@@ -146,10 +146,10 @@ class PersistenceProcessorImpl implements PersistenceProcessor {
     }
 
     @Override
-    public void addAbortToBatch(long startTimestamp, Channel c, MonitoringContext context)
+    public void addAbortToBatch(long startTimestamp, Channel c, MonitoringContext monCtx)
             throws Exception {
 
-        currentBatch.addAbort(startTimestamp, c, context);
+        currentBatch.addAbort(startTimestamp, c, monCtx);
         if (currentBatch.isFull()) {
             triggerCurrentBatchFlush();
         }
@@ -157,9 +157,19 @@ class PersistenceProcessorImpl implements PersistenceProcessor {
     }
 
     @Override
-    public void addTimestampToBatch(long startTimestamp, Channel c, MonitoringContext context) throws Exception {
+    public void addTimestampToBatch(long startTimestamp, Channel c, MonitoringContext monCtx) throws Exception {
 
-        currentBatch.addTimestamp(startTimestamp, c, context);
+        currentBatch.addTimestamp(startTimestamp, c, monCtx);
+        if (currentBatch.isFull()) {
+            triggerCurrentBatchFlush();
+        }
+
+    }
+
+    @Override
+    public void addFenceToBatch(long tableID, long fenceTimestamp, Channel c, MonitoringContext monCtx) throws Exception {
+
+        currentBatch.addFence(tableID, fenceTimestamp, c, monCtx);
         if (currentBatch.isFull()) {
             triggerCurrentBatchFlush();
         }

--- a/tso-server/src/main/java/org/apache/omid/tso/ReplyProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/ReplyProcessor.java
@@ -67,5 +67,18 @@ interface ReplyProcessor extends Closeable {
 
     void sendTimestampResponse(long startTimestamp, Channel channel);
 
+    /**
+     * Allow to send a fence response back to the client.
+     *
+     * @param tableID
+     *            the table we are creating the fence for
+     * @param fenceTimestamp
+     *            the fence timestamp to return
+     * @param channel
+     *            the channel used to send the response back to the client
+     */
+
+    void sendFenceResponse(long tableID, long fenceTimestamp, Channel c);
+
 }
 

--- a/tso-server/src/main/java/org/apache/omid/tso/ReplyProcessorImpl.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/ReplyProcessorImpl.java
@@ -67,6 +67,7 @@ class ReplyProcessorImpl implements EventHandler<ReplyProcessorImpl.ReplyBatchEv
     private final Meter abortMeter;
     private final Meter commitMeter;
     private final Meter timestampMeter;
+    private final Meter fenceMeter;
 
     @Inject
     ReplyProcessorImpl(@Named("ReplyStrategy") WaitStrategy strategy,
@@ -100,6 +101,7 @@ class ReplyProcessorImpl implements EventHandler<ReplyProcessorImpl.ReplyBatchEv
         this.abortMeter = metrics.meter(name("tso", "aborts"));
         this.commitMeter = metrics.meter(name("tso", "commits"));
         this.timestampMeter = metrics.meter(name("tso", "timestampAllocation"));
+        this.fenceMeter = metrics.meter(name("tso", "fences"));
 
         LOG.info("ReplyProcessor initialized");
 
@@ -127,6 +129,11 @@ class ReplyProcessorImpl implements EventHandler<ReplyProcessorImpl.ReplyBatchEv
                     sendTimestampResponse(event.getStartTimestamp(), event.getChannel());
                     event.getMonCtx().timerStop("reply.processor.timestamp.latency");
                     timestampMeter.mark();
+                    break;
+                case FENCE:
+                    sendFenceResponse(event.getStartTimestamp(), event.getCommitTimestamp(), event.getChannel());
+                    event.getMonCtx().timerStop("reply.processor.fence.latency");
+                    fenceMeter.mark();
                     break;
                 case COMMIT_RETRY:
                     throw new IllegalStateException("COMMIT_RETRY events must be filtered before this step: " + event);
@@ -213,6 +220,18 @@ class ReplyProcessorImpl implements EventHandler<ReplyProcessorImpl.ReplyBatchEv
         TSOProto.TimestampResponse.Builder respBuilder = TSOProto.TimestampResponse.newBuilder();
         respBuilder.setStartTimestamp(startTimestamp);
         builder.setTimestampResponse(respBuilder.build());
+        c.write(builder.build());
+
+    }
+
+    @Override
+    public void sendFenceResponse(long tableID, long fenceTimestamp, Channel c) {
+
+        TSOProto.Response.Builder builder = TSOProto.Response.newBuilder();
+        TSOProto.FenceResponse.Builder fenceBuilder = TSOProto.FenceResponse.newBuilder();
+        fenceBuilder.setTableId(tableID);
+        fenceBuilder.setFenceId(fenceTimestamp);
+        builder.setFenceResponse(fenceBuilder.build());
         c.write(builder.build());
 
     }

--- a/tso-server/src/main/java/org/apache/omid/tso/RequestProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/RequestProcessor.java
@@ -27,6 +27,7 @@ public interface RequestProcessor extends TSOStateManager.StateObserver, Closeab
 
     void timestampRequest(Channel c, MonitoringContext monCtx);
 
-    void commitRequest(long startTimestamp, Collection<Long> writeSet, boolean isRetry, Channel c, MonitoringContext monCtx);
+    void commitRequest(long startTimestamp, Collection<Long> writeSet, Collection<Long> TableIdSet, boolean isRetry, Channel c, MonitoringContext monCtx);
 
+    void fenceRequest(long tableID, Channel c, MonitoringContext monCtx);
 }

--- a/tso-server/src/main/java/org/apache/omid/tso/RequestProcessor.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/RequestProcessor.java
@@ -27,7 +27,7 @@ public interface RequestProcessor extends TSOStateManager.StateObserver, Closeab
 
     void timestampRequest(Channel c, MonitoringContext monCtx);
 
-    void commitRequest(long startTimestamp, Collection<Long> writeSet, Collection<Long> TableIdSet, boolean isRetry, Channel c, MonitoringContext monCtx);
+    void commitRequest(long startTimestamp, Collection<Long> writeSet, Collection<Long> tableIdSet, boolean isRetry, Channel c, MonitoringContext monCtx);
 
     void fenceRequest(long tableID, Channel c, MonitoringContext monCtx);
 }

--- a/tso-server/src/main/java/org/apache/omid/tso/TSOChannelHandler.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/TSOChannelHandler.java
@@ -170,9 +170,13 @@ public class TSOChannelHandler extends SimpleChannelHandler implements Closeable
                 TSOProto.CommitRequest cr = request.getCommitRequest();
                 requestProcessor.commitRequest(cr.getStartTimestamp(),
                                                cr.getCellIdList(),
+                                               cr.getTableIdList(),
                                                cr.getIsRetry(),
                                                ctx.getChannel(),
                                                new MonitoringContext(metrics));
+            } else if (request.hasFenceRequest()) {
+                TSOProto.FenceRequest fr = request.getFenceRequest();
+                requestProcessor.fenceRequest(fr.getTableId(), ctx.getChannel(), new MonitoringContext(metrics));
             } else {
                 LOG.error("Invalid request {}. Closing channel {}", request, ctx.getChannel());
                 ctx.getChannel().close();

--- a/tso-server/src/main/java/org/apache/omid/tso/TSOModule.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/TSOModule.java
@@ -24,6 +24,9 @@ import com.google.inject.Provides;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import org.apache.omid.tso.TSOServerConfig.TIMESTAMP_TYPE;
+
 import java.net.SocketException;
 import java.net.UnknownHostException;
 
@@ -43,7 +46,13 @@ class TSOModule extends AbstractModule {
 
         bind(TSOChannelHandler.class).in(Singleton.class);
         bind(TSOStateManager.class).to(TSOStateManagerImpl.class).in(Singleton.class);
-        bind(TimestampOracle.class).to(TimestampOracleImpl.class).in(Singleton.class);
+
+        if (config.getTimestampTypeEnum() == TIMESTAMP_TYPE.WORLD_TIME) {
+            bind(TimestampOracle.class).to(WorldClockOracleImpl.class).in(Singleton.class);
+        } else {
+            bind(TimestampOracle.class).to(TimestampOracleImpl.class).in(Singleton.class);
+        }
+
         bind(Panicker.class).to(SystemExitPanicker.class).in(Singleton.class);
 
         install(new BatchPoolModule(config));

--- a/tso-server/src/main/java/org/apache/omid/tso/TSOServerConfig.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/TSOServerConfig.java
@@ -44,6 +44,11 @@ public class TSOServerConfig extends SecureHBaseConfig {
         LOW_CPU
     };
 
+    public static enum TIMESTAMP_TYPE {
+      INCREMENTAL,
+      WORLD_TIME
+    };
+
     // ----------------------------------------------------------------------------------------------------------------
     // Instantiation
     // ----------------------------------------------------------------------------------------------------------------
@@ -81,6 +86,8 @@ public class TSOServerConfig extends SecureHBaseConfig {
     private String waitStrategy;
 
     private String networkIfaceName = NetworkUtils.getDefaultNetworkInterface();
+
+    private String timestampType;
 
     public int getPort() {
         return port;
@@ -128,6 +135,18 @@ public class TSOServerConfig extends SecureHBaseConfig {
 
     public void setNetworkIfaceName(String networkIfaceName) {
         this.networkIfaceName = networkIfaceName;
+    }
+
+    public String getTimestampType() {
+        return timestampType;
+    }
+
+    public void setTimestampType(String type) {
+        this.timestampType = type;
+    }
+
+    public TIMESTAMP_TYPE getTimestampTypeEnum() {
+        return TSOServerConfig.TIMESTAMP_TYPE.valueOf(timestampType);
     }
 
     public Module getTimestampStoreModule() {

--- a/tso-server/src/main/java/org/apache/omid/tso/WorldClockOracleImpl.java
+++ b/tso-server/src/main/java/org/apache/omid/tso/WorldClockOracleImpl.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.omid.tso;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.apache.omid.metrics.Gauge;
+import org.apache.omid.metrics.MetricsRegistry;
+import org.apache.omid.timestamp.storage.TimestampStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.omid.metrics.MetricsUtils.name;
+
+/**
+ * The Timestamp Oracle that gives monotonically increasing timestamps based on world time
+ */
+@Singleton
+public class WorldClockOracleImpl implements TimestampOracle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WorldClockOracleImpl.class);
+
+    static final long MAX_TX_PER_MS = 1_000_000; // 1 million
+    static final long TIMESTAMP_INTERVAL_MS = 10_000; // 10 seconds interval
+    private static final long TIMESTAMP_ALLOCATION_INTERVAL_MS = 7_000; // 7 seconds
+
+    private long lastTimestamp;
+    private long maxTimestamp;
+
+    private TimestampStorage storage;
+    private Panicker panicker;
+
+    private volatile long maxAllocatedTime;
+
+    private final ScheduledExecutorService scheduler =
+            Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setNameFormat("ts-persist-%d").build());
+
+    private Runnable allocateTimestampsBatchTask;
+
+    private class AllocateTimestampBatchTask implements Runnable {
+        long previousMaxTime;
+
+        AllocateTimestampBatchTask(long previousMaxTime) {
+            this.previousMaxTime = previousMaxTime;
+        }
+
+        @Override
+        public void run() {
+            long newMaxTime = (System.currentTimeMillis() + TIMESTAMP_INTERVAL_MS) * MAX_TX_PER_MS;
+            try {
+                storage.updateMaxTimestamp(previousMaxTime, newMaxTime);
+                maxAllocatedTime = newMaxTime;
+                previousMaxTime = newMaxTime;
+            } catch (Throwable e) {
+                panicker.panic("Can't store the new max timestamp", e);
+            }
+        }
+    }
+
+    @Inject
+    public WorldClockOracleImpl(MetricsRegistry metrics,
+                               TimestampStorage tsStorage,
+                               Panicker panicker) throws IOException {
+
+        this.storage = tsStorage;
+        this.panicker = panicker;
+
+        metrics.gauge(name("tso", "maxTimestamp"), new Gauge<Long>() {
+            @Override
+            public Long getValue() {
+                return maxTimestamp;
+            }
+        });
+
+    }
+
+    @Override
+    public void initialize() throws IOException {
+
+        this.lastTimestamp = this.maxTimestamp = storage.getMaxTimestamp();
+
+        this.allocateTimestampsBatchTask = new AllocateTimestampBatchTask(lastTimestamp);
+
+        // Trigger first allocation of timestamps
+        scheduler.schedule(allocateTimestampsBatchTask, 0, TimeUnit.MILLISECONDS);
+
+        // Waiting for the current epoch to start. Occurs in case of failover when the previous TSO allocated the current time frame.
+        while ((System.currentTimeMillis() * MAX_TX_PER_MS) < this.lastTimestamp) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+               continue;
+            }
+        }
+
+        // Launch the periodic timestamp interval allocation. In this case, the timestamp interval is extended even though the TSO is idle.
+        // Because we are world time based, this guarantees that the first request after a long time does not need to wait for new interval allocation.
+        scheduler.scheduleAtFixedRate(allocateTimestampsBatchTask, TIMESTAMP_ALLOCATION_INTERVAL_MS, TIMESTAMP_ALLOCATION_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Returns the next timestamp if available. Otherwise spins till the ts-persist thread allocates a new timestamp.
+     */
+    @Override
+    public long next() {
+
+        long currentMsFirstTimestamp = System.currentTimeMillis() * MAX_TX_PER_MS;
+
+        // Return the next timestamp in case we are still in the same millisecond as the previous timestamp was. 
+        if (++lastTimestamp >= currentMsFirstTimestamp) {
+            return lastTimestamp;
+        }
+
+        if (currentMsFirstTimestamp >= maxTimestamp) { // Intentional race to reduce synchronization overhead in every access to maxTimestamp                                                                                                                       
+            while (maxAllocatedTime <= currentMsFirstTimestamp) { // Waiting for the interval allocation
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                   continue;
+                }
+            }
+            assert (maxAllocatedTime > maxTimestamp);
+            maxTimestamp = maxAllocatedTime;
+        }
+
+        lastTimestamp = currentMsFirstTimestamp;
+
+        return lastTimestamp;
+    }
+
+    @Override
+    public long getLast() {
+        return lastTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("TimestampOracle -> LastTimestamp: %d, MaxTimestamp: %d", lastTimestamp, maxTimestamp);
+    }
+
+    @VisibleForTesting
+    static class InMemoryTimestampStorage implements TimestampStorage {
+
+        long maxTime = 0;
+
+        @Override
+        public void updateMaxTimestamp(long previousMaxTime, long nextMaxTime) {
+            maxTime = nextMaxTime;
+            LOG.info("Updating max timestamp: (previous:{}, new:{})", previousMaxTime, nextMaxTime);
+        }
+
+        @Override
+        public long getMaxTimestamp() {
+            return maxTime;
+        }
+
+    }
+}

--- a/tso-server/src/main/resources/default-omid-server-configuration.yml
+++ b/tso-server/src/main/resources/default-omid-server-configuration.yml
@@ -26,6 +26,10 @@ numConcurrentCTWriters: 2
 batchSizePerCTWriter: 25
 # When this timeout expires, the contents of the batch are flushed to the datastore
 batchPersistTimeoutInMs: 10
+# Timestamp generation strategy
+# INCREMENTAL - [Default] regular counter
+# WORLD_TIME - world time based counter
+timestampType: INCREMENTAL
 
 # Default module configuration (No TSO High Availability & in-memory storage for timestamp and commit tables)
 timestampStoreModule: !!org.apache.omid.tso.InMemoryTimestampStorageModule [ ]

--- a/tso-server/src/test/java/org/apache/omid/tso/TestWorldTimeOracle.java
+++ b/tso-server/src/test/java/org/apache/omid/tso/TestWorldTimeOracle.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.omid.tso;
+
+import org.apache.omid.metrics.MetricsRegistry;
+import org.apache.omid.timestamp.storage.TimestampStorage;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestWorldTimeOracle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestWorldTimeOracle.class);
+
+    @Mock
+    private MetricsRegistry metrics;
+    @Mock
+    private Panicker panicker;
+    @Mock
+    private TimestampStorage timestampStorage;
+
+    // Component under test
+    @InjectMocks
+    private WorldClockOracleImpl worldClockOracle;
+
+    @BeforeMethod(alwaysRun = true, timeOut = 30_000)
+    public void initMocksAndComponents() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(timeOut = 30_000)
+    public void testMonotonicTimestampGrowth() throws Exception {
+
+        // Intialize component under test
+        worldClockOracle.initialize();
+
+        long last = worldClockOracle.next();
+        
+        int timestampIntervalSec = (int) (WorldClockOracleImpl.TIMESTAMP_INTERVAL_MS / 1000) * 2;
+        for (int i = 0; i < timestampIntervalSec; i++) {
+            long current = worldClockOracle.next();
+            assertTrue(current > last+1 , "Timestamp should be based on world time");
+            last = current;
+            Thread.sleep(1000);
+        }
+
+        assertTrue(worldClockOracle.getLast() == last);
+        LOG.info("Last timestamp: {}", last);
+    }
+
+    @Test(timeOut = 10_000)
+    public void testTimestampOraclePanicsWhenTheStorageHasProblems() throws Exception {
+
+        // Intialize component under test
+        worldClockOracle.initialize();
+
+        // Cause an exception when updating the max timestamp
+        final CountDownLatch updateMaxTimestampMethodCalled = new CountDownLatch(1);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                updateMaxTimestampMethodCalled.countDown();
+                throw new RuntimeException("Out of memory or something");
+            }
+        }).when(timestampStorage).updateMaxTimestamp(anyLong(), anyLong());
+
+        // Make the previous exception to be thrown
+        Thread allocThread = new Thread("AllocThread") {
+            @Override
+            public void run() {
+                while (true) {
+                    worldClockOracle.next();
+                }
+            }
+        };
+        allocThread.start();
+
+        updateMaxTimestampMethodCalled.await();
+
+        // Verify that it has blown up
+        verify(panicker, atLeastOnce()).panic(anyString(), any(Throwable.class));
+    }
+
+}

--- a/tso-server/src/test/java/org/apache/omid/tso/client/TestTSOClientRowAndCellLevelConflict.java
+++ b/tso-server/src/test/java/org/apache/omid/tso/client/TestTSOClientRowAndCellLevelConflict.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.omid.tso.client;
+
+import com.google.common.collect.Sets;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import org.apache.omid.TestUtils;
+import org.apache.omid.tso.TSOMockModule;
+import org.apache.omid.tso.TSOServer;
+import org.apache.omid.tso.TSOServerConfig;
+import org.apache.omid.tso.client.OmidClientConfiguration.ConflictDetectionLevel;
+import org.apache.omid.tso.util.DummyCellIdImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTSOClientRowAndCellLevelConflict {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestTSOClientRowAndCellLevelConflict.class);
+
+    private static final String TSO_SERVER_HOST = "localhost";
+    private static final int TSO_SERVER_PORT = 5678;
+
+    private OmidClientConfiguration tsoClientConf;
+
+    // Required infrastructure for TSOClient test
+    private TSOServer tsoServer;
+
+    @BeforeMethod
+    public void beforeMethod() throws Exception {
+
+        TSOServerConfig tsoConfig = new TSOServerConfig();
+        tsoConfig.setConflictMapSize(1000);
+        tsoConfig.setPort(TSO_SERVER_PORT);
+        tsoConfig.setNumConcurrentCTWriters(2);
+        Module tsoServerMockModule = new TSOMockModule(tsoConfig);
+        Injector injector = Guice.createInjector(tsoServerMockModule);
+
+        LOG.info("==================================================================================================");
+        LOG.info("======================================= Init TSO Server ==========================================");
+        LOG.info("==================================================================================================");
+
+        tsoServer = injector.getInstance(TSOServer.class);
+        tsoServer.startAndWait();
+        TestUtils.waitForSocketListening(TSO_SERVER_HOST, TSO_SERVER_PORT, 100);
+
+        LOG.info("==================================================================================================");
+        LOG.info("===================================== TSO Server Initialized =====================================");
+        LOG.info("==================================================================================================");
+
+        OmidClientConfiguration tsoClientConf = new OmidClientConfiguration();
+        tsoClientConf.setConnectionString(TSO_SERVER_HOST + ":" + TSO_SERVER_PORT);
+
+        this.tsoClientConf = tsoClientConf;
+
+    }
+
+    @AfterMethod
+    public void afterMethod() throws Exception {
+        tsoServer.stopAndWait();
+        tsoServer = null;
+        TestUtils.waitForSocketNotListening(TSO_SERVER_HOST, TSO_SERVER_PORT, 1000);
+    }
+
+    @Test(timeOut = 30_000)
+    public void testRowLevelConflictAnalysisConflict() throws Exception {
+
+        tsoClientConf.setConflictAnalysisLevel(ConflictDetectionLevel.ROW);
+
+        TSOClient client = TSOClient.newInstance(tsoClientConf);
+
+        CellId c1 = new DummyCellIdImpl(0xdeadbeefL, 0xdeadbeeeL);
+        CellId c2 = new DummyCellIdImpl(0xfeedcafeL, 0xdeadbeeeL);
+
+        Set<CellId> testWriteSet1 = Sets.newHashSet(c1);
+        Set<CellId> testWriteSet2 = Sets.newHashSet(c2);
+        
+        long ts1 = client.getNewStartTimestamp().get();
+        long ts2 = client.getNewStartTimestamp().get();
+        
+        client.commit(ts1, testWriteSet1).get();
+
+        try {
+            client.commit(ts2, testWriteSet2).get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof AbortException, "Transaction should be aborted");
+            return;
+        }
+
+        assertTrue(false, "Transaction should be aborted");
+    }
+
+    @Test(timeOut = 30_000)
+    public void testRowLevelConflictAnalysisCommit() throws Exception {
+
+        tsoClientConf.setConflictAnalysisLevel(ConflictDetectionLevel.ROW);
+
+        TSOClient client = TSOClient.newInstance(tsoClientConf);
+
+        CellId c1 = new DummyCellIdImpl(0xdeadbeefL, 0xdeadbeeeL);
+        CellId c2 = new DummyCellIdImpl(0xfeedcafeL, 0xdeadbeefL);
+
+        Set<CellId> testWriteSet1 = Sets.newHashSet(c1);
+        Set<CellId> testWriteSet2 = Sets.newHashSet(c2);
+        
+        long ts1 = client.getNewStartTimestamp().get();
+        long ts2 = client.getNewStartTimestamp().get();
+        
+        client.commit(ts1, testWriteSet1).get();
+
+        try {
+            client.commit(ts2, testWriteSet2).get();
+        } catch (ExecutionException e) {
+            assertFalse(e.getCause() instanceof AbortException, "Transaction should be committed");
+            return;
+        }
+
+        assertTrue(true, "Transaction should be committed");
+    }
+
+    @Test(timeOut = 30_000)
+    public void testCellLevelConflictAnalysisConflict() throws Exception {
+
+        tsoClientConf.setConflictAnalysisLevel(ConflictDetectionLevel.CELL);
+
+        TSOClient client = TSOClient.newInstance(tsoClientConf);
+
+        CellId c1 = new DummyCellIdImpl(0xdeadbeefL, 0xdeadbeeeL);
+        CellId c2 = new DummyCellIdImpl(0xdeadbeefL, 0xdeadbeeeL);
+
+        Set<CellId> testWriteSet1 = Sets.newHashSet(c1);
+        Set<CellId> testWriteSet2 = Sets.newHashSet(c2);
+        
+        long ts1 = client.getNewStartTimestamp().get();
+        long ts2 = client.getNewStartTimestamp().get();
+        
+        client.commit(ts1, testWriteSet1).get();
+
+        try {
+            client.commit(ts2, testWriteSet2).get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof AbortException, "Transaction should be aborted");
+            return;
+        }
+
+        assertTrue(false, "Transaction should be aborted");
+    }
+
+    @Test(timeOut = 30_000)
+    public void testCellLevelConflictAnalysisCommit() throws Exception {
+
+        tsoClientConf.setConflictAnalysisLevel(ConflictDetectionLevel.CELL);
+
+        TSOClient client = TSOClient.newInstance(tsoClientConf);
+
+        CellId c1 = new DummyCellIdImpl(0xdeadbeefL, 0xdeadbeeeL);
+        CellId c2 = new DummyCellIdImpl(0xfeedcafeL, 0xdeadbeefL);
+
+        Set<CellId> testWriteSet1 = Sets.newHashSet(c1);
+        Set<CellId> testWriteSet2 = Sets.newHashSet(c2);
+        
+        long ts1 = client.getNewStartTimestamp().get();
+        long ts2 = client.getNewStartTimestamp().get();
+        
+        client.commit(ts1, testWriteSet1).get();
+
+        try {
+            client.commit(ts2, testWriteSet2).get();
+        } catch (ExecutionException e) {
+            assertFalse(e.getCause() instanceof AbortException, "Transaction should be committed");
+            return;
+        }
+
+        assertTrue(true, "Transaction should be committed");
+    }
+    
+}


### PR DESCRIPTION
This commit adds support for fences over a table. These fences guarantee that every transaction started before the fence and writes to the table the fence was created for will be aborted.
These fences are needed for creating a secondary index in Apache Phoenix. The scenario was discussed in TEPHRA-157 and PHOENIX-2478. Augmenting Omid with this kind of transactions was also discussed in OMID-56.